### PR TITLE
SAC-28235: Update circle-ci image, add [.dev] requirements, use UV / pytest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,16 +2,16 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:stitch-tap-tester
+      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:stitch-tap-tester-uv
     steps:
       - checkout
       - run:
           name: "Setup virtual env"
           command: |
-            python3 -mvenv /usr/local/share/virtualenvs/tap-amazon_ads
+            uv venv --python 3.9 /usr/local/share/virtualenvs/tap-amazon_ads
             source /usr/local/share/virtualenvs/tap-amazon_ads/bin/activate
-            pip install -U "pip==22.2.2" "setuptools==65.3.0"
-            pip install .[dev]
+            uv pip install -U "pip==22.2.2" "setuptools==65.3.0"
+            uv pip install .[dev]
       - run:
           name: "JSON Validator"
           command: |
@@ -21,15 +21,14 @@ jobs:
           name: "pylint"
           command: |
             source /usr/local/share/virtualenvs/tap-amazon_ads/bin/activate
-            pip install pylint
+            uv pip install pylint
             pylint tap_amazon_ads -d C,R,W
-      - add_ssh_keys
       - run:
           name: "Unit Tests"
           command: |
             source /usr/local/share/virtualenvs/tap-amazon_ads/bin/activate
-            pip install nose coverage
-            nosetests --with-coverage --cover-erase --cover-package=tap_amazon_ads --cover-html-dir=htmlcov tests/unittests
+            pip install coverage
+            coverage run -m pytest tests/unittests
             coverage html
       - store_test_results:
           path: test_output/report.xml
@@ -38,11 +37,11 @@ jobs:
       - run:
           name: "Integration Tests"
           command: |
+            source /usr/local/share/virtualenvs/tap-tester/bin/activate
+            uv pip install --upgrade awscli
             aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox dev_env.sh
             source dev_env.sh
-            source /usr/local/share/virtualenvs/tap-tester/bin/activate
             run-test --tap=tap-amazon_ads tests
-
 
 workflows:
   version: 2
@@ -61,4 +60,3 @@ workflows:
     jobs:
       - build:
           context: circleci-user
-

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(name="tap-amazon-ads",
         "requests==2.32.4",
         "backoff==2.2.1"
       ],
+      extras_require={"dev": ["pylint", "ipdb", "pytest"]},
       entry_points="""
           [console_scripts]
           tap-amazon-ads=tap_amazon_ads:main
@@ -25,4 +26,3 @@ setup(name="tap-amazon-ads",
       },
       include_package_data=True,
 )
-


### PR DESCRIPTION
# Description of change
- Adds extra requires [.dev] to setup
- Updates circle config to use new image, use uv, use pytest

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
