### PR TITLE
Fixed bug for schema mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,5 @@
-\
+## 1.0.0
+  * Fixed schema mismatch in `sponsored_brands_store_assets`: corrected `assetID` to `assetId` in schema definition and `key_properties` to match the Amazon Ads API response.[#11](https://github.com/singer-io/tap-amazon-ads/pull/11)
+
+## 0.0.1
+  * Initial Commit

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="tap-amazon-ads",
-      version="0.0.1",
+      version="1.0.0",
       description="Singer.io tap for extracting data from Amazon_Ads API",
       author="Stitch",
       url="http://singer.io",

--- a/tap_amazon_ads/schemas/sponsored_brands_store_assets.json
+++ b/tap_amazon_ads/schemas/sponsored_brands_store_assets.json
@@ -1,7 +1,7 @@
 {
     "type": "object",
     "properties": {
-        "assetID": {
+        "assetId": {
             "type": [
                 "null",
                 "string"

--- a/tap_amazon_ads/streams/sponsored_brands_store_assets.py
+++ b/tap_amazon_ads/streams/sponsored_brands_store_assets.py
@@ -7,7 +7,7 @@ LOGGER = get_logger()
 
 class SponsoredBrandsStoreAssets(FullTableStream):
     tap_stream_id = "sponsored_brands_store_assets"
-    key_properties = ["assetID"]
+    key_properties = ["assetId"]
     replication_method = "FULL_TABLE"
     replication_keys = []
     path = "stores/assets"


### PR DESCRIPTION
# Description of change
PR include fix applied in two places: the schema file schemas/sponsored_brands_store_assets.json and the stream class in streams/sponsored_brands_store_assets.py, where key_properties = ["assetID"] was corrected to key_properties = ["assetId"]. The fix was validated by re-running the stream against the live API and confirming the tap executed without errors and the schema aligned correctly with the response structure. [SAC-30593](https://qlik-dev.atlassian.net/browse/SAC-30593)

# Manual QA steps
- [x]  Discovery: Running
- [x]  Sync: Running
- [x]  Unit Tests: Running
- [x]  Integration test: Running
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
