### PR TITLE
Update for excluding unauth streams in catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
-## 2.0.0 [#10](https://github.com/singer-io/tap-amazon-ads/pull/10)
+## 1.0.1 [#12](https://github.com/singer-io/tap-amazon-ads/pull/12)
+- Streams the credentials cannot access (403) are now excluded from the catalog during discovery instead of raising an error.
+- Added unit tests for discovery, bookmark read/write, `modify_object`, incremental/full-table sync, sync orchestration, and `get_records` pagination.
+
+
+## 1.0.0 [#10](https://github.com/singer-io/tap-amazon-ads/pull/10)
 #### 1. Replication Keys Flattened from `extendedData` (9 streams)
 
 The replication key for 9 incremental streams was previously stored as a dot-notation path into the nested `extendedData` object (e.g., `extendedData.lastUpdateDateTime`). It is now promoted to a **top-level field** on each record (e.g., `lastUpdateDateTime`).

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="tap-amazon-ads",
-      version="1.0.0",
+      version="1.0.1",
       description="Singer.io tap for extracting data from Amazon_Ads API",
       author="Stitch",
       url="http://singer.io",

--- a/tap_amazon_ads/__init__.py
+++ b/tap_amazon_ads/__init__.py
@@ -9,12 +9,12 @@ LOGGER = singer.get_logger()
 
 REQUIRED_CONFIG_KEYS = ['refresh_token', 'client_id', 'client_secret', 'start_date', 'user_agent', 'profiles']
 
-def do_discover():
+def do_discover(client):
     """
     Discover and emit the catalog to stdout
     """
     LOGGER.info("Starting discover")
-    catalog = discover()
+    catalog = discover(client)
     json.dump(catalog.to_dict(), sys.stdout, indent=2)
     LOGGER.info("Finished discover")
 
@@ -31,7 +31,7 @@ def main():
 
     with Client(parsed_args.config) as client:
         if parsed_args.discover:
-            do_discover()
+            do_discover(client)
         elif parsed_args.catalog:
             sync(
                 client=client,

--- a/tap_amazon_ads/discover.py
+++ b/tap_amazon_ads/discover.py
@@ -6,11 +6,13 @@ from tap_amazon_ads.schema import get_schemas
 LOGGER = singer.get_logger()
 
 
-def discover() -> Catalog:
+def discover(client=None) -> Catalog:
     """
     Run the discovery mode, prepare the catalog file and return the catalog.
+    When a client is provided, access to each stream is verified and streams
+    the credentials cannot read are excluded from the returned catalog.
     """
-    schemas, field_metadata = get_schemas()
+    schemas, field_metadata = get_schemas(client)
     catalog = Catalog([])
 
     for stream_name, schema_dict in schemas.items():

--- a/tap_amazon_ads/discover.py
+++ b/tap_amazon_ads/discover.py
@@ -2,17 +2,68 @@ import singer
 from singer import metadata
 from singer.catalog import Catalog, CatalogEntry, Schema
 from tap_amazon_ads.schema import get_schemas
+from tap_amazon_ads.streams import STREAMS
+from tap_amazon_ads.exceptions import AmazonAdsForbiddenError
 
 LOGGER = singer.get_logger()
+
+
+def _prune_inaccessible_children(schemas: dict, field_metadata: dict) -> None:
+    """
+    Remove child streams from the catalog whose parent stream was excluded.
+    Mutates schemas and field_metadata in place.
+    """
+    for name, stream_cls in list(STREAMS.items()):
+        if name in schemas and stream_cls.parent and stream_cls.parent not in schemas:
+            LOGGER.warning(
+                "Stream '%s' excluded from catalog because its parent stream '%s' is not accessible.",
+                name, stream_cls.parent,
+            )
+            schemas.pop(name)
+            field_metadata.pop(name)
+
+
+def _apply_access_checks(client, schemas: dict, field_metadata: dict) -> None:
+    """
+    Probe each parent stream for read access and remove inaccessible streams
+    (and their children) from schemas and field_metadata in place.
+    Raises AmazonAdsForbiddenError if no parent streams are accessible.
+    """
+    error_list = [
+        stream_name
+        for stream_name, stream_obj in STREAMS.items()
+        if stream_name in schemas
+        and not stream_obj(client=client).check_access()
+    ]
+    for stream_name in error_list:
+        schemas.pop(stream_name, None)
+        field_metadata.pop(stream_name, None)
+
+    _prune_inaccessible_children(schemas, field_metadata)
+
+    if error_list:
+        total_parent_streams = len([s for s in STREAMS.values() if not s.parent])
+        if len(error_list) == total_parent_streams:
+            raise AmazonAdsForbiddenError(
+                "HTTP-error-code: 403, Error: The account credentials supplied do not have 'read' access to any "
+                "of the streams supported by the tap. Data collection cannot be initiated due to lack of permissions."
+            )
+        LOGGER.warning(
+            "The account credentials supplied do not have 'read' access to the following stream(s): %s. "
+            "These streams have been excluded from the catalog.",
+            ", ".join(error_list),
+        )
 
 
 def discover(client) -> Catalog:
     """
     Run the discovery mode, prepare the catalog file and return the catalog.
-    When a client is provided, access to each stream is verified and streams
+    Access to each stream is verified using the provided client and streams
     the credentials cannot read are excluded from the returned catalog.
     """
-    schemas, field_metadata = get_schemas(client)
+    schemas, field_metadata = get_schemas()
+    _apply_access_checks(client, schemas, field_metadata)
+
     catalog = Catalog([])
 
     for stream_name, schema_dict in schemas.items():

--- a/tap_amazon_ads/discover.py
+++ b/tap_amazon_ads/discover.py
@@ -29,21 +29,21 @@ def _apply_access_checks(client, schemas: dict, field_metadata: dict) -> None:
     (and their children) from schemas and field_metadata in place.
     Raises AmazonAdsForbiddenError if no parent streams are accessible.
     """
-    error_list = [
+    inaccessible_streams = [
         stream_name
         for stream_name, stream_obj in STREAMS.items()
         if stream_name in schemas
         and not stream_obj(client=client).check_access()
     ]
-    for stream_name in error_list:
+    for stream_name in inaccessible_streams:
         schemas.pop(stream_name, None)
         field_metadata.pop(stream_name, None)
 
     _prune_inaccessible_children(schemas, field_metadata)
 
-    if error_list:
+    if inaccessible_streams:
         total_parent_streams = len([s for s in STREAMS.values() if not s.parent])
-        if len(error_list) == total_parent_streams:
+        if len(inaccessible_streams) == total_parent_streams:
             raise AmazonAdsForbiddenError(
                 "HTTP-error-code: 403, Error: The account credentials supplied do not have 'read' access to any "
                 "of the streams supported by the tap. Data collection cannot be initiated due to lack of permissions."
@@ -51,7 +51,7 @@ def _apply_access_checks(client, schemas: dict, field_metadata: dict) -> None:
         LOGGER.warning(
             "The account credentials supplied do not have 'read' access to the following stream(s): %s. "
             "These streams have been excluded from the catalog.",
-            ", ".join(error_list),
+            ", ".join(inaccessible_streams),
         )
 
 

--- a/tap_amazon_ads/discover.py
+++ b/tap_amazon_ads/discover.py
@@ -6,7 +6,7 @@ from tap_amazon_ads.schema import get_schemas
 LOGGER = singer.get_logger()
 
 
-def discover(client=None) -> Catalog:
+def discover(client) -> Catalog:
     """
     Run the discovery mode, prepare the catalog file and return the catalog.
     When a client is provided, access to each stream is verified and streams

--- a/tap_amazon_ads/schema.py
+++ b/tap_amazon_ads/schema.py
@@ -77,7 +77,6 @@ def get_schemas(client=None) -> Tuple[Dict, Dict]:
         if parent_tap_stream_id:
             mdata = metadata.write(mdata, (), 'parent-tap-stream-id', parent_tap_stream_id)
 
-        mdata = metadata.write(mdata, (), 'selected', True)
         mdata = metadata.to_list(mdata)
         field_metadata[stream_name] = mdata
 

--- a/tap_amazon_ads/schema.py
+++ b/tap_amazon_ads/schema.py
@@ -4,6 +4,7 @@ import singer
 from typing import Dict, Tuple
 from singer import metadata
 from tap_amazon_ads.streams import STREAMS
+from tap_amazon_ads.exceptions import AmazonAdsForbiddenError
 
 LOGGER = singer.get_logger()
 
@@ -37,12 +38,15 @@ def load_schema_references() -> Dict:
     return refs
 
 
-def get_schemas() -> Tuple[Dict, Dict]:
+def get_schemas(client=None) -> Tuple[Dict, Dict]:
     """
     Load the schema references, prepare metadata for each streams and return schema and metadata for the catalog.
+    If a client is provided, each parent stream's access is verified; streams the credentials cannot read
+    are excluded from the returned catalog along with any of their child streams.
     """
     schemas = {}
     field_metadata = {}
+    error_list = []
 
     refs = load_schema_references()
     for stream_name, stream_obj in STREAMS.items():
@@ -73,8 +77,51 @@ def get_schemas() -> Tuple[Dict, Dict]:
         if parent_tap_stream_id:
             mdata = metadata.write(mdata, (), 'parent-tap-stream-id', parent_tap_stream_id)
 
+        mdata = metadata.write(mdata, (), 'selected', True)
         mdata = metadata.to_list(mdata)
         field_metadata[stream_name] = mdata
+
+        if client:
+            try:
+                # Call check_access only for parent (top-level) streams.
+                # If the credentials lack read permission, AmazonAdsForbiddenError is raised
+                # by the client and the stream is excluded from the catalog.
+                instance = stream_obj(client=client)
+                if not instance.parent:
+                    instance.check_access()
+            except AmazonAdsForbiddenError:
+                LOGGER.warning(
+                    "Stream '%s' does not have read permission, excluding from catalog.",
+                    stream_name,
+                )
+                schemas.pop(stream_name, None)
+                field_metadata.pop(stream_name, None)
+                error_list.append(stream_name)
+
+    if client:
+        # Remove child streams whose parent was excluded.
+        for name, stream_cls in list(STREAMS.items()):
+            if name in schemas and stream_cls.parent and stream_cls.parent not in schemas:
+                LOGGER.warning(
+                    "Stream '%s' excluded from catalog because its parent stream '%s' is not accessible.",
+                    name, stream_cls.parent,
+                )
+                schemas.pop(name, None)
+                field_metadata.pop(name, None)
+
+        if error_list:
+            total_parent_streams = len([s for s in STREAMS.values() if not s.parent])
+            streams_name = ", ".join(error_list)
+            if len(error_list) == total_parent_streams:
+                raise AmazonAdsForbiddenError(
+                    "HTTP-error-code: 403, Error: The account credentials supplied do not have 'read' access to any "
+                    "of the streams supported by the tap. Data collection cannot be initiated due to lack of permissions."
+                )
+            LOGGER.warning(
+                "The account credentials supplied do not have 'read' access to the following stream(s): %s. "
+                "These streams have been excluded from the catalog.",
+                streams_name,
+            )
 
     return schemas, field_metadata
 

--- a/tap_amazon_ads/schema.py
+++ b/tap_amazon_ads/schema.py
@@ -1,10 +1,9 @@
 import os
 import json
 import singer
-from typing import Dict, List, Tuple
+from typing import Dict, Tuple
 from singer import metadata
 from tap_amazon_ads.streams import STREAMS
-from tap_amazon_ads.exceptions import AmazonAdsForbiddenError
 
 LOGGER = singer.get_logger()
 
@@ -38,120 +37,43 @@ def load_schema_references() -> Dict:
     return refs
 
 
-def _load_schema(stream_name: str) -> Dict:
+def get_schemas() -> Tuple[Dict, Dict]:
     """
-    Load the raw JSON schema for a single stream from disk.
-    """
-    schema_path = get_abs_path(f"schemas/{stream_name}.json")
-    with open(schema_path) as file:
-        return json.load(file)
-
-
-def _build_metadata(stream_obj, schema: Dict) -> List:
-    """
-    Build Singer catalog metadata for a stream from its resolved schema.
-    Returns a metadata list suitable for a catalog entry.
-    """
-    mdata = metadata.new()
-    mdata = metadata.get_standard_metadata(
-        schema=schema,
-        key_properties=getattr(stream_obj, "key_properties"),
-        valid_replication_keys=(getattr(stream_obj, "replication_keys") or []),
-        replication_method=getattr(stream_obj, "replication_method"),
-    )
-    mdata = metadata.to_map(mdata)
-
-    # Explicitly mark replication key fields as automatic inclusion.
-    for field_name in (getattr(stream_obj, "replication_keys") or []):
-        if field_name in schema.get("properties", {}):
-            mdata = metadata.write(
-                mdata, ("properties", field_name), "inclusion", "automatic"
-            )
-
-    parent_tap_stream_id = getattr(stream_obj, "parent", None)
-    if parent_tap_stream_id:
-        mdata = metadata.write(mdata, (), "parent-tap-stream-id", parent_tap_stream_id)
-
-    return metadata.to_list(mdata)
-
-
-def _validate_stream_access(client, stream_name: str, stream_obj) -> bool:
-    """
-    Probe whether the client credentials have read access to a parent stream.
-    Child streams are skipped (they are validated implicitly via parent exclusion).
-    Returns True if accessible or if the stream is a child; False on 403 Forbidden.
-    """
-    instance = stream_obj(client=client)
-    if instance.parent:
-        return True  # child access is governed by the parent check
-    try:
-        instance.check_access()
-        return True
-    except AmazonAdsForbiddenError:
-        LOGGER.warning(
-            "Stream '%s' does not have read permission, excluding from catalog.",
-            stream_name,
-        )
-        return False
-
-
-def _prune_inaccessible_children(schemas: Dict, field_metadata: Dict) -> None:
-    """
-    Remove child streams from the catalog whose parent stream was excluded.
-    Mutates schemas and field_metadata in place.
-    """
-    for name, stream_cls in list(STREAMS.items()):
-        if name in schemas and stream_cls.parent and stream_cls.parent not in schemas:
-            LOGGER.warning(
-                "Stream '%s' excluded from catalog because its parent stream '%s' is not accessible.",
-                name, stream_cls.parent,
-            )
-            schemas.pop(name)
-            field_metadata.pop(name)
-
-
-def get_schemas(client) -> Tuple[Dict, Dict]:
-    """
-    Build catalog schemas and metadata for all streams.
-    If a client is provided, streams that the credentials cannot access (HTTP 403)
-    are excluded from the returned catalog along with any of their child streams.
-    Raises AmazonAdsForbiddenError if no parent streams are accessible.
-    Pass None to skip access checks (e.g. in unit tests or when running without credentials).
+    Load schemas and build Singer catalog metadata for all streams.
+    Returns raw schemas and metadata dicts keyed by stream name.
+    Access checks are the caller's responsibility (see discover()).
     """
     schemas = {}
     field_metadata = {}
 
     refs = load_schema_references()
     for stream_name, stream_obj in STREAMS.items():
-        raw_schema = _load_schema(stream_name)
+        schema_path = get_abs_path(f"schemas/{stream_name}.json")
+        with open(schema_path) as file:
+            raw_schema = json.load(file)
         schemas[stream_name] = raw_schema
+
         resolved_schema = singer.resolve_schema_references(raw_schema, refs)
-        field_metadata[stream_name] = _build_metadata(stream_obj, resolved_schema)
 
-    if client:
-        error_list = [
-            stream_name
-            for stream_name, stream_obj in STREAMS.items()
-            if stream_name in schemas
-            and not _validate_stream_access(client, stream_name, stream_obj)
-        ]
-        for stream_name in error_list:
-            schemas.pop(stream_name, None)
-            field_metadata.pop(stream_name, None)
+        mdata = metadata.new()
+        mdata = metadata.get_standard_metadata(
+            schema=resolved_schema,
+            key_properties=getattr(stream_obj, "key_properties"),
+            valid_replication_keys=(getattr(stream_obj, "replication_keys") or []),
+            replication_method=getattr(stream_obj, "replication_method"),
+        )
+        mdata = metadata.to_map(mdata)
 
-        _prune_inaccessible_children(schemas, field_metadata)
-
-        if error_list:
-            total_parent_streams = len([s for s in STREAMS.values() if not s.parent])
-            if len(error_list) == total_parent_streams:
-                raise AmazonAdsForbiddenError(
-                    "HTTP-error-code: 403, Error: The account credentials supplied do not have 'read' access to any "
-                    "of the streams supported by the tap. Data collection cannot be initiated due to lack of permissions."
+        for field_name in (getattr(stream_obj, "replication_keys") or []):
+            if field_name in resolved_schema.get("properties", {}):
+                mdata = metadata.write(
+                    mdata, ("properties", field_name), "inclusion", "automatic"
                 )
-            LOGGER.warning(
-                "The account credentials supplied do not have 'read' access to the following stream(s): %s. "
-                "These streams have been excluded from the catalog.",
-                ", ".join(error_list),
-            )
+
+        parent_tap_stream_id = getattr(stream_obj, "parent", None)
+        if parent_tap_stream_id:
+            mdata = metadata.write(mdata, (), "parent-tap-stream-id", parent_tap_stream_id)
+
+        field_metadata[stream_name] = metadata.to_list(mdata)
 
     return schemas, field_metadata

--- a/tap_amazon_ads/schema.py
+++ b/tap_amazon_ads/schema.py
@@ -123,4 +123,3 @@ def get_schemas(client=None) -> Tuple[Dict, Dict]:
             )
 
     return schemas, field_metadata
-

--- a/tap_amazon_ads/schema.py
+++ b/tap_amazon_ads/schema.py
@@ -1,7 +1,7 @@
 import os
 import json
 import singer
-from typing import Dict, Tuple
+from typing import Dict, List, Tuple
 from singer import metadata
 from tap_amazon_ads.streams import STREAMS
 from tap_amazon_ads.exceptions import AmazonAdsForbiddenError
@@ -38,79 +38,111 @@ def load_schema_references() -> Dict:
     return refs
 
 
-def get_schemas(client=None) -> Tuple[Dict, Dict]:
+def _load_schema(stream_name: str) -> Dict:
     """
-    Load the schema references, prepare metadata for each streams and return schema and metadata for the catalog.
-    If a client is provided, each parent stream's access is verified; streams the credentials cannot read
+    Load the raw JSON schema for a single stream from disk.
+    """
+    schema_path = get_abs_path(f"schemas/{stream_name}.json")
+    with open(schema_path) as file:
+        return json.load(file)
+
+
+def _build_metadata(stream_obj, schema: Dict) -> List:
+    """
+    Build Singer catalog metadata for a stream from its resolved schema.
+    Returns a metadata list suitable for a catalog entry.
+    """
+    mdata = metadata.new()
+    mdata = metadata.get_standard_metadata(
+        schema=schema,
+        key_properties=getattr(stream_obj, "key_properties"),
+        valid_replication_keys=(getattr(stream_obj, "replication_keys") or []),
+        replication_method=getattr(stream_obj, "replication_method"),
+    )
+    mdata = metadata.to_map(mdata)
+
+    # Explicitly mark replication key fields as automatic inclusion.
+    for field_name in (getattr(stream_obj, "replication_keys") or []):
+        if field_name in schema.get("properties", {}):
+            mdata = metadata.write(
+                mdata, ("properties", field_name), "inclusion", "automatic"
+            )
+
+    parent_tap_stream_id = getattr(stream_obj, "parent", None)
+    if parent_tap_stream_id:
+        mdata = metadata.write(mdata, (), "parent-tap-stream-id", parent_tap_stream_id)
+
+    return metadata.to_list(mdata)
+
+
+def _validate_stream_access(client, stream_name: str, stream_obj) -> bool:
+    """
+    Probe whether the client credentials have read access to a parent stream.
+    Child streams are skipped (they are validated implicitly via parent exclusion).
+    Returns True if accessible or if the stream is a child; False on 403 Forbidden.
+    """
+    instance = stream_obj(client=client)
+    if instance.parent:
+        return True  # child access is governed by the parent check
+    try:
+        instance.check_access()
+        return True
+    except AmazonAdsForbiddenError:
+        LOGGER.warning(
+            "Stream '%s' does not have read permission, excluding from catalog.",
+            stream_name,
+        )
+        return False
+
+
+def _prune_inaccessible_children(schemas: Dict, field_metadata: Dict) -> None:
+    """
+    Remove child streams from the catalog whose parent stream was excluded.
+    Mutates schemas and field_metadata in place.
+    """
+    for name, stream_cls in list(STREAMS.items()):
+        if name in schemas and stream_cls.parent and stream_cls.parent not in schemas:
+            LOGGER.warning(
+                "Stream '%s' excluded from catalog because its parent stream '%s' is not accessible.",
+                name, stream_cls.parent,
+            )
+            schemas.pop(name)
+            field_metadata.pop(name)
+
+
+def get_schemas(client) -> Tuple[Dict, Dict]:
+    """
+    Build catalog schemas and metadata for all streams.
+    If a client is provided, streams that the credentials cannot access (HTTP 403)
     are excluded from the returned catalog along with any of their child streams.
+    Raises AmazonAdsForbiddenError if no parent streams are accessible.
+    Pass None to skip access checks (e.g. in unit tests or when running without credentials).
     """
     schemas = {}
     field_metadata = {}
-    error_list = []
 
     refs = load_schema_references()
     for stream_name, stream_obj in STREAMS.items():
-        schema_path = get_abs_path("schemas/{}.json".format(stream_name))
-        with open(schema_path) as file:
-            schema = json.load(file)
-
-        schemas[stream_name] = schema
-        schema = singer.resolve_schema_references(schema, refs)
-
-        mdata = metadata.new()
-        mdata = metadata.get_standard_metadata(
-            schema=schema,
-            key_properties=getattr(stream_obj, "key_properties"),
-            valid_replication_keys=(getattr(stream_obj, "replication_keys") or []),
-            replication_method=getattr(stream_obj, "replication_method"),
-        )
-        mdata = metadata.to_map(mdata)
-
-        automatic_keys = getattr(stream_obj, "replication_keys") or []
-        for field_name in schema["properties"].keys():
-            if field_name in automatic_keys:
-                mdata = metadata.write(
-                    mdata, ("properties", field_name), "inclusion", "automatic"
-                )
-
-        parent_tap_stream_id = getattr(stream_obj, "parent", None)
-        if parent_tap_stream_id:
-            mdata = metadata.write(mdata, (), 'parent-tap-stream-id', parent_tap_stream_id)
-
-        mdata = metadata.to_list(mdata)
-        field_metadata[stream_name] = mdata
-
-        if client:
-            try:
-                # Call check_access only for parent (top-level) streams.
-                # If the credentials lack read permission, AmazonAdsForbiddenError is raised
-                # by the client and the stream is excluded from the catalog.
-                instance = stream_obj(client=client)
-                if not instance.parent:
-                    instance.check_access()
-            except AmazonAdsForbiddenError:
-                LOGGER.warning(
-                    "Stream '%s' does not have read permission, excluding from catalog.",
-                    stream_name,
-                )
-                schemas.pop(stream_name, None)
-                field_metadata.pop(stream_name, None)
-                error_list.append(stream_name)
+        raw_schema = _load_schema(stream_name)
+        schemas[stream_name] = raw_schema
+        resolved_schema = singer.resolve_schema_references(raw_schema, refs)
+        field_metadata[stream_name] = _build_metadata(stream_obj, resolved_schema)
 
     if client:
-        # Remove child streams whose parent was excluded.
-        for name, stream_cls in list(STREAMS.items()):
-            if name in schemas and stream_cls.parent and stream_cls.parent not in schemas:
-                LOGGER.warning(
-                    "Stream '%s' excluded from catalog because its parent stream '%s' is not accessible.",
-                    name, stream_cls.parent,
-                )
-                schemas.pop(name, None)
-                field_metadata.pop(name, None)
+        error_list = [
+            stream_name
+            for stream_name, stream_obj in STREAMS.items()
+            if stream_name in schemas
+            and not _validate_stream_access(client, stream_name, stream_obj)
+        ]
+        for stream_name in error_list:
+            schemas.pop(stream_name, None)
+            field_metadata.pop(stream_name, None)
+
+        _prune_inaccessible_children(schemas, field_metadata)
 
         if error_list:
             total_parent_streams = len([s for s in STREAMS.values() if not s.parent])
-            streams_name = ", ".join(error_list)
             if len(error_list) == total_parent_streams:
                 raise AmazonAdsForbiddenError(
                     "HTTP-error-code: 403, Error: The account credentials supplied do not have 'read' access to any "
@@ -119,7 +151,7 @@ def get_schemas(client=None) -> Tuple[Dict, Dict]:
             LOGGER.warning(
                 "The account credentials supplied do not have 'read' access to the following stream(s): %s. "
                 "These streams have been excluded from the catalog.",
-                streams_name,
+                ", ".join(error_list),
             )
 
     return schemas, field_metadata

--- a/tap_amazon_ads/streams/abstracts.py
+++ b/tap_amazon_ads/streams/abstracts.py
@@ -44,12 +44,12 @@ class BaseStream(ABC):
     def __init__(self, client=None, catalog=None) -> None:
         self.client = client
         self.catalog = catalog
-        self.schema = catalog.schema.to_dict()
-        self.metadata = metadata.to_map(catalog.metadata)
+        self.schema = catalog.schema.to_dict() if catalog else {}
+        self.metadata = metadata.to_map(catalog.metadata) if catalog else {}
         self.child_to_sync = []
         self.params = {}
         self.data_payload = dict()
-        self.page_size = self.client.config.get("page_size", self.page_size)
+        self.page_size = self.client.config.get("page_size", self.page_size) if client else self.page_size
 
     @property
     @abstractmethod
@@ -198,6 +198,27 @@ class BaseStream(ABC):
             else:
                 return default
         return value
+
+    def check_access(self):
+        """
+        Verify that the API credentials have read access to this stream.
+        Makes a minimal request to the stream's endpoint. If the credentials
+        lack permission, the client will raise AmazonAdsForbiddenError.
+        """
+        url = self.get_url_endpoint()
+        self.update_params()
+        if self.http_method == "POST":
+            self.update_data_payload()
+            body = json.dumps(self.data_payload)
+        else:
+            body = None
+        self.client.make_request(
+            self.http_method,
+            url,
+            self.params,
+            self.headers,
+            body=body,
+        )
 
     def update_pagination_key(self, response):
         """

--- a/tap_amazon_ads/streams/abstracts.py
+++ b/tap_amazon_ads/streams/abstracts.py
@@ -1,6 +1,7 @@
 from abc import ABC, abstractmethod
 from typing import Any, Dict, Tuple, Iterator, List
 import json
+from tap_amazon_ads.exceptions import AmazonAdsForbiddenError
 from singer import (
     Transformer,
     get_bookmark,
@@ -199,12 +200,14 @@ class BaseStream(ABC):
                 return default
         return value
 
-    def check_access(self):
+    def check_access(self) -> bool:
         """
         Verify that the API credentials have read access to this stream.
-        Makes a minimal request to the stream's endpoint. If the credentials
-        lack permission, the client will raise AmazonAdsForbiddenError.
+        Returns True if accessible, False if a 403 Forbidden error is raised.
+        Child streams always return True (access is governed by the parent check).
         """
+        if self.parent:
+            return True
         url = self.get_url_endpoint()
         self.update_params()
         if self.http_method == "POST":
@@ -212,13 +215,21 @@ class BaseStream(ABC):
             body = json.dumps(self.data_payload)
         else:
             body = None
-        self.client.make_request(
-            self.http_method,
-            url,
-            self.params,
-            self.headers,
-            body=body,
-        )
+        try:
+            self.client.make_request(
+                self.http_method,
+                url,
+                self.params,
+                self.headers,
+                body=body,
+            )
+            return True
+        except AmazonAdsForbiddenError:
+            LOGGER.warning(
+                "Stream '%s' does not have read permission, excluding from catalog.",
+                self.__class__.__name__,
+            )
+            return False
 
     def update_pagination_key(self, response):
         """

--- a/tests/unittests/test_bookmarks.py
+++ b/tests/unittests/test_bookmarks.py
@@ -1,0 +1,274 @@
+import unittest
+from unittest.mock import patch, MagicMock, call
+from singer import get_bookmark
+from tap_amazon_ads.streams.abstracts import IncrementalStream
+
+
+# ---------------------------------------------------------------------------
+# Minimal concrete subclass used across all bookmark tests
+# ---------------------------------------------------------------------------
+
+class _Stream(IncrementalStream):
+    tap_stream_id = "test_stream"
+    key_properties = ["id"]
+    replication_keys = ["lastUpdateDateTime"]
+    replication_method = "INCREMENTAL"
+    http_method = "POST"
+    data_key = "items"
+    path = "items/list"
+    pagination_in = "body"
+
+
+def _make_stream(config=None):
+    """Factory: returns a fully wired _Stream instance with mock client/catalog."""
+    patcher = patch("tap_amazon_ads.streams.abstracts.metadata.to_map")
+    mock_to_map = patcher.start()
+    mock_to_map.return_value = {(): {"selected": True}}
+
+    client = MagicMock()
+    client.config = config or {"start_date": "2024-01-01T00:00:00Z"}
+    client.base_url = "https://advertising.amazon.com"
+
+    catalog = MagicMock()
+    catalog.schema.to_dict.return_value = {
+        "properties": {
+            "id": {"type": ["null", "string"]},
+            "lastUpdateDateTime": {"type": ["null", "string"], "format": "date-time"},
+        }
+    }
+    catalog.metadata = []
+
+    stream = _Stream(client=client, catalog=catalog)
+    stream.child_to_sync = []
+    patcher.stop()
+    return stream
+
+
+# ---------------------------------------------------------------------------
+# get_bookmark tests
+# ---------------------------------------------------------------------------
+
+class TestGetBookmark(unittest.TestCase):
+    """Tests for IncrementalStream.get_bookmark()"""
+
+    def setUp(self):
+        self.stream = _make_stream()
+
+    def test_returns_existing_bookmark(self):
+        """Returns the stored bookmark value when present in state."""
+        state = {
+            "bookmarks": {
+                "test_stream": {"lastUpdateDateTime": "2025-06-01T00:00:00Z"}
+            }
+        }
+        result = self.stream.get_bookmark(state, "test_stream")
+        self.assertEqual(result, "2025-06-01T00:00:00Z")
+
+    def test_falls_back_to_start_date_when_no_bookmark(self):
+        """Falls back to config start_date when the stream has no bookmark."""
+        state = {}
+        result = self.stream.get_bookmark(state, "test_stream")
+        self.assertEqual(result, "2024-01-01T00:00:00Z")
+
+    def test_explicit_key_overrides_replication_key(self):
+        """When a custom key is passed, it is used instead of replication_keys[0]."""
+        state = {
+            "bookmarks": {
+                "test_stream": {
+                    "custom_key": "2025-03-15T00:00:00Z",
+                    "lastUpdateDateTime": "2024-01-01T00:00:00Z",
+                }
+            }
+        }
+        result = self.stream.get_bookmark(state, "test_stream", key="custom_key")
+        self.assertEqual(result, "2025-03-15T00:00:00Z")
+
+    def test_falls_back_to_start_date_for_unknown_stream(self):
+        """An unknown stream name returns start_date as fallback."""
+        state = {"bookmarks": {"other_stream": {"lastUpdateDateTime": "2025-01-01T00:00:00Z"}}}
+        result = self.stream.get_bookmark(state, "test_stream")
+        self.assertEqual(result, "2024-01-01T00:00:00Z")
+
+
+# ---------------------------------------------------------------------------
+# write_bookmark tests
+# ---------------------------------------------------------------------------
+
+class TestWriteBookmark(unittest.TestCase):
+    """Tests for IncrementalStream.write_bookmark()"""
+
+    def setUp(self):
+        self.stream = _make_stream()
+
+    def test_writes_bookmark_when_value_is_greater(self):
+        """New value greater than existing bookmark is persisted."""
+        state = {
+            "bookmarks": {
+                "test_stream": {"lastUpdateDateTime": "2024-06-01T00:00:00Z"}
+            }
+        }
+        new_state = self.stream.write_bookmark(
+            state, "test_stream", value="2025-01-01T00:00:00Z"
+        )
+        bookmark = new_state["bookmarks"]["test_stream"]["lastUpdateDateTime"]
+        self.assertEqual(bookmark, "2025-01-01T00:00:00Z")
+
+    def test_does_not_regress_bookmark_to_older_value(self):
+        """A value older than the existing bookmark keeps the existing bookmark."""
+        state = {
+            "bookmarks": {
+                "test_stream": {"lastUpdateDateTime": "2025-01-01T00:00:00Z"}
+            }
+        }
+        new_state = self.stream.write_bookmark(
+            state, "test_stream", value="2024-01-01T00:00:00Z"
+        )
+        bookmark = new_state["bookmarks"]["test_stream"]["lastUpdateDateTime"]
+        self.assertEqual(bookmark, "2025-01-01T00:00:00Z")
+
+    def test_writes_bookmark_when_no_prior_bookmark(self):
+        """Bookmark is written correctly when no prior bookmark exists."""
+        state = {}
+        new_state = self.stream.write_bookmark(
+            state, "test_stream", value="2025-03-01T00:00:00Z"
+        )
+        bookmark = new_state["bookmarks"]["test_stream"]["lastUpdateDateTime"]
+        self.assertEqual(bookmark, "2025-03-01T00:00:00Z")
+
+    def test_write_bookmark_returns_state_unchanged_when_no_replication_keys(self):
+        """Returns state unmodified when stream has no replication keys and no key arg."""
+        stream = _make_stream()
+        stream.replication_keys = []
+        state = {"bookmarks": {}}
+        result = stream.write_bookmark(state, "test_stream", value="2025-01-01T00:00:00Z")
+        self.assertEqual(result, {"bookmarks": {}})
+
+    def test_writes_with_explicit_key(self):
+        """Bookmark is written under the explicitly provided key."""
+        state = {}
+        new_state = self.stream.write_bookmark(
+            state, "test_stream", key="custom_key", value="2025-07-01T00:00:00Z"
+        )
+        bookmark = new_state["bookmarks"]["test_stream"]["custom_key"]
+        self.assertEqual(bookmark, "2025-07-01T00:00:00Z")
+
+
+# ---------------------------------------------------------------------------
+# modify_object / extendedData promotion tests
+# ---------------------------------------------------------------------------
+
+class TestModifyObject(unittest.TestCase):
+    """Tests for BaseStream.modify_object() — the extendedData promotion logic."""
+
+    def setUp(self):
+        self.stream = _make_stream()
+
+    def test_promotes_replication_key_from_extended_data(self):
+        """modify_object promotes the replication key from extendedData to top level."""
+        record = {
+            "id": "1",
+            "extendedData": {"lastUpdateDateTime": "2025-05-01T00:00:00Z"},
+        }
+        result = self.stream.modify_object(record)
+        self.assertEqual(result["lastUpdateDateTime"], "2025-05-01T00:00:00Z")
+
+    def test_does_not_overwrite_existing_top_level_value(self):
+        """If the key is already present at top level AND in extendedData, extendedData wins."""
+        record = {
+            "id": "1",
+            "lastUpdateDateTime": "2024-01-01T00:00:00Z",
+            "extendedData": {"lastUpdateDateTime": "2025-05-01T00:00:00Z"},
+        }
+        result = self.stream.modify_object(record)
+        self.assertEqual(result["lastUpdateDateTime"], "2025-05-01T00:00:00Z")
+
+    def test_leaves_record_unchanged_when_extended_data_absent(self):
+        """When extendedData is absent, the record is returned unmodified."""
+        record = {"id": "1", "name": "test"}
+        result = self.stream.modify_object(record)
+        self.assertNotIn("lastUpdateDateTime", result)
+        self.assertEqual(result, {"id": "1", "name": "test"})
+
+    def test_leaves_record_unchanged_when_key_not_in_extended_data(self):
+        """When the replication key is not in extendedData, the record is unmodified."""
+        record = {"id": "1", "extendedData": {"someOtherField": "value"}}
+        result = self.stream.modify_object(record)
+        self.assertNotIn("lastUpdateDateTime", result)
+
+    def test_handles_non_dict_extended_data_gracefully(self):
+        """If extendedData is not a dict, modify_object does not crash."""
+        record = {"id": "1", "extendedData": None}
+        result = self.stream.modify_object(record)
+        self.assertNotIn("lastUpdateDateTime", result)
+
+    def test_no_op_for_full_table_stream(self):
+        """A stream with empty replication_keys leaves the record unchanged."""
+        stream = _make_stream()
+        stream.replication_keys = []
+        record = {"id": "1", "extendedData": {"lastUpdateDateTime": "2025-01-01T00:00:00Z"}}
+        result = stream.modify_object(record)
+        self.assertNotIn("lastUpdateDateTime", result)
+
+
+# ---------------------------------------------------------------------------
+# Bookmark state across sync runs (integration-style unit test)
+# ---------------------------------------------------------------------------
+
+class TestBookmarkAdvancesAfterSync(unittest.TestCase):
+    """
+    Verifies that after a sync run the bookmark is set to the maximum
+    replication key value seen in the records — simulating the bookmark
+    advancing correctly across runs.
+    """
+
+    def _run_sync(self, records, initial_bookmark):
+        """Helper: run a sync with a mocked get_records and return final state."""
+        import singer
+        stream = _make_stream(config={"start_date": "2024-01-01T00:00:00Z"})
+        stream.url_endpoint = "https://advertising.amazon.com/sp/campaigns/list"
+
+        state = {
+            "bookmarks": {
+                "test_stream": {"lastUpdateDateTime": initial_bookmark}
+            }
+        }
+
+        with patch.object(stream, "get_records", return_value=iter(records)), \
+             patch("tap_amazon_ads.streams.abstracts.write_record"), \
+             patch("tap_amazon_ads.streams.abstracts.metrics.record_counter") as mock_counter:
+
+            mock_ctx = MagicMock()
+            mock_ctx.__enter__ = MagicMock(return_value=mock_ctx)
+            mock_ctx.__exit__ = MagicMock(return_value=False)
+            mock_counter.return_value = mock_ctx
+
+            with singer.Transformer() as transformer:
+                _, final_state = stream.sync(state=state, transformer=transformer)
+
+        return final_state
+
+    def test_bookmark_advances_to_max_record_date(self):
+        """After sync, bookmark should be the maximum replication key in the records."""
+        records = [
+            {"id": "1", "lastUpdateDateTime": "2025-01-10T00:00:00Z"},
+            {"id": "2", "lastUpdateDateTime": "2025-03-15T00:00:00Z"},
+            {"id": "3", "lastUpdateDateTime": "2025-02-01T00:00:00Z"},
+        ]
+        final_state = self._run_sync(records, "2025-01-01T00:00:00Z")
+        bookmark = final_state["bookmarks"]["test_stream"]["lastUpdateDateTime"]
+        self.assertEqual(bookmark, "2025-03-15T00:00:00Z")
+
+    def test_bookmark_does_not_regress_when_all_records_are_older(self):
+        """If all records are older than the bookmark, bookmark stays unchanged."""
+        records = [
+            {"id": "1", "lastUpdateDateTime": "2023-06-01T00:00:00Z"},
+        ]
+        final_state = self._run_sync(records, "2025-01-01T00:00:00Z")
+        bookmark = final_state["bookmarks"]["test_stream"]["lastUpdateDateTime"]
+        self.assertEqual(bookmark, "2025-01-01T00:00:00Z")
+
+    def test_bookmark_stays_at_start_date_when_no_records(self):
+        """With no records, bookmark remains at start_date."""
+        final_state = self._run_sync([], "2024-01-01T00:00:00Z")
+        bookmark = final_state["bookmarks"]["test_stream"]["lastUpdateDateTime"]
+        self.assertEqual(bookmark, "2024-01-01T00:00:00Z")

--- a/tests/unittests/test_bookmarks.py
+++ b/tests/unittests/test_bookmarks.py
@@ -172,8 +172,8 @@ class TestModifyObject(unittest.TestCase):
         result = self.stream.modify_object(record)
         self.assertEqual(result["lastUpdateDateTime"], "2025-05-01T00:00:00Z")
 
-    def test_does_not_overwrite_existing_top_level_value(self):
-        """If the key is already present at top level AND in extendedData, extendedData wins."""
+    def test_extended_data_takes_precedence_over_top_level_value(self):
+        """extendedData value overwrites an existing top-level value for the replication key."""
         record = {
             "id": "1",
             "lastUpdateDateTime": "2024-01-01T00:00:00Z",

--- a/tests/unittests/test_discovery.py
+++ b/tests/unittests/test_discovery.py
@@ -1,7 +1,7 @@
 import unittest
 from unittest.mock import patch, MagicMock, mock_open
 from singer.catalog import Catalog, CatalogEntry
-from tap_amazon_ads.discover import discover
+from tap_amazon_ads.discover import discover, _apply_access_checks
 from tap_amazon_ads.schema import get_schemas
 from tap_amazon_ads.streams import STREAMS
 from tap_amazon_ads.exceptions import AmazonAdsForbiddenError
@@ -12,13 +12,13 @@ class TestGetSchemas(unittest.TestCase):
 
     def test_returns_all_streams(self):
         """get_schemas() should return an entry for every stream in STREAMS."""
-        schemas, field_metadata = get_schemas(None)
+        schemas, field_metadata = get_schemas()
         self.assertEqual(set(schemas.keys()), set(STREAMS.keys()))
         self.assertEqual(set(field_metadata.keys()), set(STREAMS.keys()))
 
     def test_schema_properties_are_dicts(self):
         """Every schema returned should have a 'properties' dict."""
-        schemas, _ = get_schemas(None)
+        schemas, _ = get_schemas()
         for stream_name, schema in schemas.items():
             with self.subTest(stream=stream_name):
                 self.assertIn("properties", schema, f"{stream_name} schema missing 'properties'")
@@ -26,7 +26,7 @@ class TestGetSchemas(unittest.TestCase):
 
     def test_incremental_streams_have_replication_key_in_metadata(self):
         """All incremental streams should mark their replication key as 'automatic' in metadata."""
-        _, field_metadata = get_schemas(None)
+        _, field_metadata = get_schemas()
         for stream_name, stream_cls in STREAMS.items():
             rk = getattr(stream_cls, "replication_keys", [])
             if not rk:
@@ -48,7 +48,7 @@ class TestGetSchemas(unittest.TestCase):
 
     def test_primary_keys_in_metadata(self):
         """Every stream should have its key_properties recorded in root metadata."""
-        _, field_metadata = get_schemas(None)
+        _, field_metadata = get_schemas()
         for stream_name, stream_cls in STREAMS.items():
             expected_keys = list(getattr(stream_cls, "key_properties", []))
             mdata_list = field_metadata[stream_name]
@@ -66,7 +66,7 @@ class TestGetSchemas(unittest.TestCase):
 
     def test_replication_method_in_metadata(self):
         """Every stream should have its replication method recorded in root metadata."""
-        _, field_metadata = get_schemas(None)
+        _, field_metadata = get_schemas()
         for stream_name, stream_cls in STREAMS.items():
             expected_method = getattr(stream_cls, "replication_method")
             mdata_list = field_metadata[stream_name]
@@ -80,7 +80,7 @@ class TestGetSchemas(unittest.TestCase):
 
     def test_replication_key_present_in_schema_properties(self):
         """For every incremental stream, the replication key must exist as a schema property."""
-        schemas, _ = get_schemas(None)
+        schemas, _ = get_schemas()
         for stream_name, stream_cls in STREAMS.items():
             rk = getattr(stream_cls, "replication_keys", [])
             if not rk:
@@ -94,7 +94,7 @@ class TestGetSchemas(unittest.TestCase):
 
     def test_replication_key_has_date_time_format(self):
         """Every replication key field in the schema must have format=date-time."""
-        schemas, _ = get_schemas(None)
+        schemas, _ = get_schemas()
         for stream_name, stream_cls in STREAMS.items():
             rk = getattr(stream_cls, "replication_keys", [])
             if not rk:
@@ -109,7 +109,7 @@ class TestGetSchemas(unittest.TestCase):
 
     def test_primary_key_fields_exist_in_schema_properties(self):
         """Every key_property must be a property in the schema."""
-        schemas, _ = get_schemas(None)
+        schemas, _ = get_schemas()
         for stream_name, stream_cls in STREAMS.items():
             keys = getattr(stream_cls, "key_properties", [])
             props = schemas[stream_name].get("properties", {})
@@ -125,20 +125,29 @@ class TestGetSchemas(unittest.TestCase):
 class TestDiscover(unittest.TestCase):
     """Unit tests for tap_amazon_ads.discover.discover()"""
 
+    def setUp(self):
+        """Patch _apply_access_checks for tests that check catalog structure."""
+        self._patcher = patch("tap_amazon_ads.discover._apply_access_checks")
+        self._patcher.start()
+        self.mock_client = MagicMock()
+
+    def tearDown(self):
+        self._patcher.stop()
+
     def test_discover_returns_catalog(self):
         """discover() should return a singer Catalog object."""
-        catalog = discover(None)
+        catalog = discover(self.mock_client)
         self.assertIsInstance(catalog, Catalog)
 
     def test_discover_catalog_contains_all_streams(self):
         """The catalog should contain an entry for every stream in STREAMS."""
-        catalog = discover(None)
+        catalog = discover(self.mock_client)
         catalog_stream_names = {entry.stream for entry in catalog.streams}
         self.assertEqual(catalog_stream_names, set(STREAMS.keys()))
 
     def test_catalog_entry_has_key_properties(self):
         """Every catalog entry must have non-empty key_properties."""
-        catalog = discover(None)
+        catalog = discover(self.mock_client)
         for entry in catalog.streams:
             with self.subTest(stream=entry.stream):
                 self.assertIsNotNone(entry.key_properties)
@@ -150,7 +159,7 @@ class TestDiscover(unittest.TestCase):
 
     def test_catalog_entry_has_schema(self):
         """Every catalog entry must have a schema with properties."""
-        catalog = discover(None)
+        catalog = discover(self.mock_client)
         for entry in catalog.streams:
             with self.subTest(stream=entry.stream):
                 schema_dict = entry.schema.to_dict()
@@ -158,7 +167,7 @@ class TestDiscover(unittest.TestCase):
 
     def test_catalog_entry_has_metadata(self):
         """Every catalog entry must have metadata."""
-        catalog = discover(None)
+        catalog = discover(self.mock_client)
         for entry in catalog.streams:
             with self.subTest(stream=entry.stream):
                 self.assertIsNotNone(entry.metadata)
@@ -166,7 +175,7 @@ class TestDiscover(unittest.TestCase):
 
     def test_catalog_tap_stream_id_matches_stream(self):
         """tap_stream_id must match the stream name for every entry."""
-        catalog = discover(None)
+        catalog = discover(self.mock_client)
         for entry in catalog.streams:
             with self.subTest(stream=entry.stream):
                 self.assertEqual(entry.stream, entry.tap_stream_id)
@@ -177,11 +186,11 @@ class TestDiscover(unittest.TestCase):
         bad_metadata = {"broken_stream": []}
         with patch("tap_amazon_ads.discover.get_schemas", return_value=(bad_schemas, bad_metadata)):
             with self.assertRaises(Exception):
-                discover(None)
+                discover(self.mock_client)
 
     def test_key_properties_match_stream_class(self):
         """key_properties in catalog must match the stream class definition."""
-        catalog = discover(None)
+        catalog = discover(self.mock_client)
         for entry in catalog.streams:
             stream_cls = STREAMS[entry.stream]
             expected = sorted(getattr(stream_cls, "key_properties", []))
@@ -189,12 +198,27 @@ class TestDiscover(unittest.TestCase):
             with self.subTest(stream=entry.stream):
                 self.assertEqual(actual, expected)
 
+    def test_discover_always_calls_access_checks(self):
+        """discover() always calls _apply_access_checks unconditionally."""
+        with patch("tap_amazon_ads.discover._apply_access_checks") as mock_check, \
+             patch("tap_amazon_ads.discover.get_schemas", return_value=({}, {})):
+            discover(self.mock_client)
+        mock_check.assert_called_once_with(self.mock_client, {}, {})
+
+    def test_client_triggers_access_checks(self):
+        """discover(client) must call _apply_access_checks with the client."""
+        mock_client = MagicMock()
+        with patch("tap_amazon_ads.discover._apply_access_checks") as mock_check, \
+             patch("tap_amazon_ads.discover.get_schemas", return_value=({}, {})):
+            discover(mock_client)
+        mock_check.assert_called_once_with(mock_client, {}, {})
+
 
 # ---------------------------------------------------------------------------
 # Helpers for access-check unit tests
 # ---------------------------------------------------------------------------
 
-def _make_stream_cls(parent="", check_access_raises=None):
+def _make_stream_cls(parent="", check_access_returns=True):
     """
     Build a minimal mock stream *class* that get_schemas can iterate over and
     instantiate.
@@ -211,42 +235,23 @@ def _make_stream_cls(parent="", check_access_raises=None):
 
     instance = cls.return_value
     instance.parent = parent
-    if check_access_raises is not None:
-        instance.check_access.side_effect = check_access_raises
-    else:
-        instance.check_access.return_value = None  # success – no exception raised
+    instance.check_access.return_value = check_access_returns
     return cls
 
 
 class TestGetSchemasAccessCheck(unittest.TestCase):
-    """Unit tests for the access-check logic added to get_schemas()."""
+    """Unit tests for the access-check logic in discover._apply_access_checks()."""
 
     def setUp(self):
         self.client = MagicMock()
 
-        self._patchers = [
-            patch("tap_amazon_ads.schema.load_schema_references", return_value={}),
-            patch(
-                "tap_amazon_ads.schema.singer.resolve_schema_references",
-                side_effect=lambda schema, refs: schema,
-            ),
-            patch("builtins.open", mock_open(read_data='{"properties": {}}')),
-            patch("tap_amazon_ads.schema.metadata.new", return_value={}),
-            patch("tap_amazon_ads.schema.metadata.get_standard_metadata", return_value=[]),
-            patch("tap_amazon_ads.schema.metadata.to_map", return_value={}),
-            patch("tap_amazon_ads.schema.metadata.write", return_value={}),
-            patch("tap_amazon_ads.schema.metadata.to_list", return_value=[]),
-        ]
-        for p in self._patchers:
-            p.start()
-
-    def tearDown(self):
-        for p in self._patchers:
-            p.stop()
-
     def _run(self, streams_dict):
-        with patch("tap_amazon_ads.schema.STREAMS", streams_dict):
-            return get_schemas(self.client)
+        """Build stub schemas/metadata and run _apply_access_checks with the given streams."""
+        schemas = {name: {"properties": {}} for name in streams_dict}
+        field_metadata = {name: [] for name in streams_dict}
+        with patch("tap_amazon_ads.discover.STREAMS", streams_dict):
+            _apply_access_checks(self.client, schemas, field_metadata)
+        return schemas, field_metadata
 
     # ------------------------------------------------------------------
     # Basic inclusion / exclusion
@@ -263,23 +268,22 @@ class TestGetSchemasAccessCheck(unittest.TestCase):
         self.assertIn("ads", schemas)
         self.assertEqual(len(schemas), 2)
 
-    def test_check_access_called_only_for_parent_streams(self):
-        """check_access must be invoked for parent streams and skipped for child streams."""
+    def test_check_access_called_for_all_streams(self):
+        """check_access is called for all streams; children return True immediately
+        via their own check_access implementation (parent skip is inside check_access)."""
         campaigns_cls = _make_stream_cls(parent="")
         ads_cls = _make_stream_cls(parent="campaigns")
 
         self._run({"campaigns": campaigns_cls, "ads": ads_cls})
 
         campaigns_cls.return_value.check_access.assert_called_once()
-        ads_cls.return_value.check_access.assert_not_called()
+        ads_cls.return_value.check_access.assert_called_once()
 
     def test_forbidden_parent_stream_excluded_from_catalog(self):
-        """A parent stream that raises AmazonAdsForbiddenError is removed from
+        """A parent stream whose check_access returns False is removed from
         both schemas and field_metadata."""
         ok_cls = _make_stream_cls(parent="")
-        forbidden_cls = _make_stream_cls(
-            parent="", check_access_raises=AmazonAdsForbiddenError("403")
-        )
+        forbidden_cls = _make_stream_cls(parent="", check_access_returns=False)
 
         schemas, mdata = self._run({"ok_stream": ok_cls, "forbidden_stream": forbidden_cls})
 
@@ -292,10 +296,8 @@ class TestGetSchemasAccessCheck(unittest.TestCase):
     # ------------------------------------------------------------------
 
     def test_children_excluded_when_parent_is_forbidden(self):
-        """Child streams of a 403-excluded parent are removed by orphan pruning."""
-        campaigns_cls = _make_stream_cls(
-            parent="", check_access_raises=AmazonAdsForbiddenError("403")
-        )
+        """Child streams of an excluded parent are removed by orphan pruning."""
+        campaigns_cls = _make_stream_cls(parent="", check_access_returns=False)
         ads_cls = _make_stream_cls(parent="campaigns")
         keywords_cls = _make_stream_cls(parent="campaigns")
         ok_cls = _make_stream_cls(parent="")
@@ -316,9 +318,7 @@ class TestGetSchemasAccessCheck(unittest.TestCase):
 
     def test_grandchild_excluded_via_single_pass_pruning(self):
         """Orphan pruning cascades: grandchildren are removed when their parent is pruned."""
-        campaigns_cls = _make_stream_cls(
-            parent="", check_access_raises=AmazonAdsForbiddenError("403")
-        )
+        campaigns_cls = _make_stream_cls(parent="", check_access_returns=False)
         ads_cls = _make_stream_cls(parent="campaigns")
         creatives_cls = _make_stream_cls(parent="ads")  # grandchild
         ok_cls = _make_stream_cls(parent="")
@@ -352,10 +352,8 @@ class TestGetSchemasAccessCheck(unittest.TestCase):
     # ------------------------------------------------------------------
 
     def test_all_parent_streams_forbidden_raises_error(self):
-        """When every parent stream is unauthorised, AmazonAdsForbiddenError is raised."""
-        forbidden_cls = _make_stream_cls(
-            parent="", check_access_raises=AmazonAdsForbiddenError("403")
-        )
+        """When every parent stream returns False from check_access, AmazonAdsForbiddenError is raised."""
+        forbidden_cls = _make_stream_cls(parent="", check_access_returns=False)
 
         with self.assertRaises(AmazonAdsForbiddenError):
             self._run({"campaigns": forbidden_cls})
@@ -364,9 +362,7 @@ class TestGetSchemasAccessCheck(unittest.TestCase):
         """When some (but not all) parent streams fail, no exception is raised and
         only the authorised streams are returned."""
         ok_cls = _make_stream_cls(parent="")
-        forbidden_cls = _make_stream_cls(
-            parent="", check_access_raises=AmazonAdsForbiddenError("403")
-        )
+        forbidden_cls = _make_stream_cls(parent="", check_access_returns=False)
 
         # Must not raise
         schemas, _ = self._run({"ok_stream": ok_cls, "forbidden_stream": forbidden_cls})
@@ -375,18 +371,9 @@ class TestGetSchemasAccessCheck(unittest.TestCase):
         self.assertNotIn("forbidden_stream", schemas)
 
     # ------------------------------------------------------------------
-    # No-client path (backward compatibility)
+    # No-client path — tested in TestDiscover
+    # (discover(None) skips _apply_access_checks entirely)
     # ------------------------------------------------------------------
-
-    def test_no_client_skips_access_check(self):
-        """Calling get_schemas() without a client must not invoke check_access."""
-        stream_cls = _make_stream_cls(parent="")
-
-        with patch("tap_amazon_ads.schema.STREAMS", {"some_stream": stream_cls}):
-            schemas, _ = get_schemas(None)  # explicit None — no access check
-
-        stream_cls.return_value.check_access.assert_not_called()
-        self.assertIn("some_stream", schemas)
 
 
 class TestDiscoverWithAccessCheck(unittest.TestCase):
@@ -402,19 +389,21 @@ class TestDiscoverWithAccessCheck(unittest.TestCase):
         with patch(
             "tap_amazon_ads.discover.get_schemas",
             return_value=(allowed_schemas, allowed_metadata),
-        ) as mock_get_schemas:
+        ) as mock_get_schemas, \
+             patch("tap_amazon_ads.discover._apply_access_checks"):
             catalog = discover(mock_client)
 
-        mock_get_schemas.assert_called_once_with(mock_client)
+        mock_get_schemas.assert_called_once_with()
         catalog_stream_names = {e.stream for e in catalog.streams}
         self.assertEqual(catalog_stream_names, {"profiles"})
 
-    def test_discover_without_client_calls_get_schemas_with_none(self):
-        """discover(None) passes None to get_schemas, skipping access checks."""
+    def test_discover_calls_get_schemas_without_arguments(self):
+        """discover() always calls get_schemas() with no arguments — client is not passed."""
         with patch(
             "tap_amazon_ads.discover.get_schemas",
             return_value=({}, {}),
-        ) as mock_get_schemas:
+        ) as mock_get_schemas, \
+             patch("tap_amazon_ads.discover._apply_access_checks"):
             discover(None)
 
-        mock_get_schemas.assert_called_once_with(None)
+        mock_get_schemas.assert_called_once_with()

--- a/tests/unittests/test_discovery.py
+++ b/tests/unittests/test_discovery.py
@@ -78,21 +78,6 @@ class TestGetSchemas(unittest.TestCase):
                 actual_method = root_entry["metadata"].get("forced-replication-method")
                 self.assertEqual(actual_method, expected_method)
 
-    def test_all_streams_selected_by_default(self):
-        """All streams should have selected=True in root metadata (auto-selected)."""
-        _, field_metadata = get_schemas()
-        for stream_name in STREAMS:
-            mdata_list = field_metadata[stream_name]
-            root_entry = next(
-                (e for e in mdata_list if not e["breadcrumb"]), None
-            )
-            with self.subTest(stream=stream_name):
-                self.assertIsNotNone(root_entry)
-                self.assertTrue(
-                    root_entry["metadata"].get("selected"),
-                    f"{stream_name}: expected selected=True in metadata",
-                )
-
     def test_replication_key_present_in_schema_properties(self):
         """For every incremental stream, the replication key must exist as a schema property."""
         schemas, _ = get_schemas()

--- a/tests/unittests/test_discovery.py
+++ b/tests/unittests/test_discovery.py
@@ -1,0 +1,435 @@
+import unittest
+from unittest.mock import patch, MagicMock, mock_open
+from singer.catalog import Catalog, CatalogEntry
+from tap_amazon_ads.discover import discover
+from tap_amazon_ads.schema import get_schemas
+from tap_amazon_ads.streams import STREAMS
+from tap_amazon_ads.exceptions import AmazonAdsForbiddenError
+
+
+class TestGetSchemas(unittest.TestCase):
+    """Unit tests for tap_amazon_ads.schema.get_schemas()"""
+
+    def test_returns_all_streams(self):
+        """get_schemas() should return an entry for every stream in STREAMS."""
+        schemas, field_metadata = get_schemas()
+        self.assertEqual(set(schemas.keys()), set(STREAMS.keys()))
+        self.assertEqual(set(field_metadata.keys()), set(STREAMS.keys()))
+
+    def test_schema_properties_are_dicts(self):
+        """Every schema returned should have a 'properties' dict."""
+        schemas, _ = get_schemas()
+        for stream_name, schema in schemas.items():
+            with self.subTest(stream=stream_name):
+                self.assertIn("properties", schema, f"{stream_name} schema missing 'properties'")
+                self.assertIsInstance(schema["properties"], dict)
+
+    def test_incremental_streams_have_replication_key_in_metadata(self):
+        """All incremental streams should mark their replication key as 'automatic' in metadata."""
+        _, field_metadata = get_schemas()
+        for stream_name, stream_cls in STREAMS.items():
+            rk = getattr(stream_cls, "replication_keys", [])
+            if not rk:
+                continue
+            mdata_list = field_metadata[stream_name]
+            automatic_fields = [
+                entry["breadcrumb"][1]
+                for entry in mdata_list
+                if len(entry["breadcrumb"]) == 2
+                and entry["breadcrumb"][0] == "properties"
+                and entry["metadata"].get("inclusion") == "automatic"
+            ]
+            with self.subTest(stream=stream_name):
+                self.assertIn(
+                    rk[0],
+                    automatic_fields,
+                    f"{stream_name}: replication key '{rk[0]}' not marked automatic",
+                )
+
+    def test_primary_keys_in_metadata(self):
+        """Every stream should have its key_properties recorded in root metadata."""
+        _, field_metadata = get_schemas()
+        for stream_name, stream_cls in STREAMS.items():
+            expected_keys = list(getattr(stream_cls, "key_properties", []))
+            mdata_list = field_metadata[stream_name]
+            root_entry = next(
+                (e for e in mdata_list if not e["breadcrumb"]), None
+            )
+            with self.subTest(stream=stream_name):
+                self.assertIsNotNone(root_entry, f"{stream_name}: no root metadata entry")
+                actual_keys = root_entry["metadata"].get("table-key-properties", [])
+                self.assertEqual(
+                    sorted(actual_keys),
+                    sorted(expected_keys),
+                    f"{stream_name}: key_properties mismatch",
+                )
+
+    def test_replication_method_in_metadata(self):
+        """Every stream should have its replication method recorded in root metadata."""
+        _, field_metadata = get_schemas()
+        for stream_name, stream_cls in STREAMS.items():
+            expected_method = getattr(stream_cls, "replication_method")
+            mdata_list = field_metadata[stream_name]
+            root_entry = next(
+                (e for e in mdata_list if not e["breadcrumb"]), None
+            )
+            with self.subTest(stream=stream_name):
+                self.assertIsNotNone(root_entry)
+                actual_method = root_entry["metadata"].get("forced-replication-method")
+                self.assertEqual(actual_method, expected_method)
+
+    def test_all_streams_selected_by_default(self):
+        """All streams should have selected=True in root metadata (auto-selected)."""
+        _, field_metadata = get_schemas()
+        for stream_name in STREAMS:
+            mdata_list = field_metadata[stream_name]
+            root_entry = next(
+                (e for e in mdata_list if not e["breadcrumb"]), None
+            )
+            with self.subTest(stream=stream_name):
+                self.assertIsNotNone(root_entry)
+                self.assertTrue(
+                    root_entry["metadata"].get("selected"),
+                    f"{stream_name}: expected selected=True in metadata",
+                )
+
+    def test_replication_key_present_in_schema_properties(self):
+        """For every incremental stream, the replication key must exist as a schema property."""
+        schemas, _ = get_schemas()
+        for stream_name, stream_cls in STREAMS.items():
+            rk = getattr(stream_cls, "replication_keys", [])
+            if not rk:
+                continue
+            with self.subTest(stream=stream_name):
+                self.assertIn(
+                    rk[0],
+                    schemas[stream_name]["properties"],
+                    f"{stream_name}: replication key '{rk[0]}' not in schema properties",
+                )
+
+    def test_replication_key_has_date_time_format(self):
+        """Every replication key field in the schema must have format=date-time."""
+        schemas, _ = get_schemas()
+        for stream_name, stream_cls in STREAMS.items():
+            rk = getattr(stream_cls, "replication_keys", [])
+            if not rk:
+                continue
+            field_def = schemas[stream_name]["properties"].get(rk[0], {})
+            with self.subTest(stream=stream_name):
+                self.assertEqual(
+                    field_def.get("format"),
+                    "date-time",
+                    f"{stream_name}: replication key '{rk[0]}' missing format:date-time",
+                )
+
+    def test_primary_key_fields_exist_in_schema_properties(self):
+        """Every key_property must be a property in the schema."""
+        schemas, _ = get_schemas()
+        for stream_name, stream_cls in STREAMS.items():
+            keys = getattr(stream_cls, "key_properties", [])
+            props = schemas[stream_name].get("properties", {})
+            for key in keys:
+                with self.subTest(stream=stream_name, key=key):
+                    self.assertIn(
+                        key,
+                        props,
+                        f"{stream_name}: key_property '{key}' not in schema properties",
+                    )
+
+
+class TestDiscover(unittest.TestCase):
+    """Unit tests for tap_amazon_ads.discover.discover()"""
+
+    def test_discover_returns_catalog(self):
+        """discover() should return a singer Catalog object."""
+        catalog = discover()
+        self.assertIsInstance(catalog, Catalog)
+
+    def test_discover_catalog_contains_all_streams(self):
+        """The catalog should contain an entry for every stream in STREAMS."""
+        catalog = discover()
+        catalog_stream_names = {entry.stream for entry in catalog.streams}
+        self.assertEqual(catalog_stream_names, set(STREAMS.keys()))
+
+    def test_catalog_entry_has_key_properties(self):
+        """Every catalog entry must have non-empty key_properties."""
+        catalog = discover()
+        for entry in catalog.streams:
+            with self.subTest(stream=entry.stream):
+                self.assertIsNotNone(entry.key_properties)
+                self.assertGreater(
+                    len(entry.key_properties),
+                    0,
+                    f"{entry.stream}: key_properties should not be empty",
+                )
+
+    def test_catalog_entry_has_schema(self):
+        """Every catalog entry must have a schema with properties."""
+        catalog = discover()
+        for entry in catalog.streams:
+            with self.subTest(stream=entry.stream):
+                schema_dict = entry.schema.to_dict()
+                self.assertIn("properties", schema_dict)
+
+    def test_catalog_entry_has_metadata(self):
+        """Every catalog entry must have metadata."""
+        catalog = discover()
+        for entry in catalog.streams:
+            with self.subTest(stream=entry.stream):
+                self.assertIsNotNone(entry.metadata)
+                self.assertGreater(len(entry.metadata), 0)
+
+    def test_catalog_tap_stream_id_matches_stream(self):
+        """tap_stream_id must match the stream name for every entry."""
+        catalog = discover()
+        for entry in catalog.streams:
+            with self.subTest(stream=entry.stream):
+                self.assertEqual(entry.stream, entry.tap_stream_id)
+
+    def test_discover_raises_on_bad_schema(self):
+        """discover() must propagate errors if a schema file can't be loaded."""
+        bad_schemas = {"broken_stream": "not-a-dict"}
+        bad_metadata = {"broken_stream": []}
+        with patch("tap_amazon_ads.discover.get_schemas", return_value=(bad_schemas, bad_metadata)):
+            with self.assertRaises(Exception):
+                discover()
+
+    def test_key_properties_match_stream_class(self):
+        """key_properties in catalog must match the stream class definition."""
+        catalog = discover()
+        for entry in catalog.streams:
+            stream_cls = STREAMS[entry.stream]
+            expected = sorted(getattr(stream_cls, "key_properties", []))
+            actual = sorted(entry.key_properties or [])
+            with self.subTest(stream=entry.stream):
+                self.assertEqual(actual, expected)
+
+
+# ---------------------------------------------------------------------------
+# Helpers for access-check unit tests
+# ---------------------------------------------------------------------------
+
+def _make_stream_cls(parent="", check_access_raises=None):
+    """
+    Build a minimal mock stream *class* that get_schemas can iterate over and
+    instantiate.
+
+    Class-level attributes (parent, replication_keys, …) are consumed by
+    get_schemas before instantiation; the instance returned by calling the
+    class controls the check_access behaviour.
+    """
+    cls = MagicMock()
+    cls.parent = parent
+    cls.replication_keys = []
+    cls.key_properties = ["id"]
+    cls.replication_method = "FULL_TABLE"
+
+    instance = cls.return_value
+    instance.parent = parent
+    if check_access_raises is not None:
+        instance.check_access.side_effect = check_access_raises
+    else:
+        instance.check_access.return_value = None  # success – no exception raised
+    return cls
+
+
+class TestGetSchemasAccessCheck(unittest.TestCase):
+    """Unit tests for the access-check logic added to get_schemas()."""
+
+    def setUp(self):
+        self.client = MagicMock()
+
+        self._patchers = [
+            patch("tap_amazon_ads.schema.load_schema_references", return_value={}),
+            patch(
+                "tap_amazon_ads.schema.singer.resolve_schema_references",
+                side_effect=lambda schema, refs: schema,
+            ),
+            patch("builtins.open", mock_open(read_data='{"properties": {}}')),
+            patch("tap_amazon_ads.schema.metadata.new", return_value={}),
+            patch("tap_amazon_ads.schema.metadata.get_standard_metadata", return_value=[]),
+            patch("tap_amazon_ads.schema.metadata.to_map", return_value={}),
+            patch("tap_amazon_ads.schema.metadata.write", return_value={}),
+            patch("tap_amazon_ads.schema.metadata.to_list", return_value=[]),
+        ]
+        for p in self._patchers:
+            p.start()
+
+    def tearDown(self):
+        for p in self._patchers:
+            p.stop()
+
+    def _run(self, streams_dict):
+        with patch("tap_amazon_ads.schema.STREAMS", streams_dict):
+            return get_schemas(self.client)
+
+    # ------------------------------------------------------------------
+    # Basic inclusion / exclusion
+    # ------------------------------------------------------------------
+
+    def test_all_accessible_streams_included(self):
+        """All parent streams that pass check_access appear in the returned schemas."""
+        campaigns_cls = _make_stream_cls(parent="")
+        ads_cls = _make_stream_cls(parent="campaigns")  # child – skipped
+
+        schemas, mdata = self._run({"campaigns": campaigns_cls, "ads": ads_cls})
+
+        self.assertIn("campaigns", schemas)
+        self.assertIn("ads", schemas)
+        self.assertEqual(len(schemas), 2)
+
+    def test_check_access_called_only_for_parent_streams(self):
+        """check_access must be invoked for parent streams and skipped for child streams."""
+        campaigns_cls = _make_stream_cls(parent="")
+        ads_cls = _make_stream_cls(parent="campaigns")
+
+        self._run({"campaigns": campaigns_cls, "ads": ads_cls})
+
+        campaigns_cls.return_value.check_access.assert_called_once()
+        ads_cls.return_value.check_access.assert_not_called()
+
+    def test_forbidden_parent_stream_excluded_from_catalog(self):
+        """A parent stream that raises AmazonAdsForbiddenError is removed from
+        both schemas and field_metadata."""
+        ok_cls = _make_stream_cls(parent="")
+        forbidden_cls = _make_stream_cls(
+            parent="", check_access_raises=AmazonAdsForbiddenError("403")
+        )
+
+        schemas, mdata = self._run({"ok_stream": ok_cls, "forbidden_stream": forbidden_cls})
+
+        self.assertIn("ok_stream", schemas)
+        self.assertNotIn("forbidden_stream", schemas)
+        self.assertNotIn("forbidden_stream", mdata)
+
+    # ------------------------------------------------------------------
+    # Orphan-child pruning
+    # ------------------------------------------------------------------
+
+    def test_children_excluded_when_parent_is_forbidden(self):
+        """Child streams of a 403-excluded parent are removed by orphan pruning."""
+        campaigns_cls = _make_stream_cls(
+            parent="", check_access_raises=AmazonAdsForbiddenError("403")
+        )
+        ads_cls = _make_stream_cls(parent="campaigns")
+        keywords_cls = _make_stream_cls(parent="campaigns")
+        ok_cls = _make_stream_cls(parent="")
+
+        schemas, _ = self._run(
+            {
+                "campaigns": campaigns_cls,
+                "ads": ads_cls,
+                "keywords": keywords_cls,
+                "ok_stream": ok_cls,
+            }
+        )
+
+        self.assertNotIn("campaigns", schemas)
+        self.assertNotIn("ads", schemas)
+        self.assertNotIn("keywords", schemas)
+        self.assertIn("ok_stream", schemas)
+
+    def test_grandchild_excluded_via_single_pass_pruning(self):
+        """Orphan pruning cascades: grandchildren are removed when their parent is pruned."""
+        campaigns_cls = _make_stream_cls(
+            parent="", check_access_raises=AmazonAdsForbiddenError("403")
+        )
+        ads_cls = _make_stream_cls(parent="campaigns")
+        creatives_cls = _make_stream_cls(parent="ads")  # grandchild
+        ok_cls = _make_stream_cls(parent="")
+
+        schemas, _ = self._run(
+            {
+                "campaigns": campaigns_cls,
+                "ads": ads_cls,
+                "creatives": creatives_cls,
+                "ok_stream": ok_cls,
+            }
+        )
+
+        self.assertNotIn("campaigns", schemas)
+        self.assertNotIn("ads", schemas)
+        self.assertNotIn("creatives", schemas)
+        self.assertIn("ok_stream", schemas)
+
+    def test_child_not_pruned_when_parent_accessible(self):
+        """Children are kept in the catalog when their parent passes access check."""
+        campaigns_cls = _make_stream_cls(parent="")
+        ads_cls = _make_stream_cls(parent="campaigns")
+
+        schemas, _ = self._run({"campaigns": campaigns_cls, "ads": ads_cls})
+
+        self.assertIn("campaigns", schemas)
+        self.assertIn("ads", schemas)
+
+    # ------------------------------------------------------------------
+    # Error propagation
+    # ------------------------------------------------------------------
+
+    def test_all_parent_streams_forbidden_raises_error(self):
+        """When every parent stream is unauthorised, AmazonAdsForbiddenError is raised."""
+        forbidden_cls = _make_stream_cls(
+            parent="", check_access_raises=AmazonAdsForbiddenError("403")
+        )
+
+        with self.assertRaises(AmazonAdsForbiddenError):
+            self._run({"campaigns": forbidden_cls})
+
+    def test_partial_403_does_not_raise(self):
+        """When some (but not all) parent streams fail, no exception is raised and
+        only the authorised streams are returned."""
+        ok_cls = _make_stream_cls(parent="")
+        forbidden_cls = _make_stream_cls(
+            parent="", check_access_raises=AmazonAdsForbiddenError("403")
+        )
+
+        # Must not raise
+        schemas, _ = self._run({"ok_stream": ok_cls, "forbidden_stream": forbidden_cls})
+
+        self.assertIn("ok_stream", schemas)
+        self.assertNotIn("forbidden_stream", schemas)
+
+    # ------------------------------------------------------------------
+    # No-client path (backward compatibility)
+    # ------------------------------------------------------------------
+
+    def test_no_client_skips_access_check(self):
+        """Calling get_schemas() without a client must not invoke check_access."""
+        stream_cls = _make_stream_cls(parent="")
+
+        with patch("tap_amazon_ads.schema.STREAMS", {"some_stream": stream_cls}):
+            schemas, _ = get_schemas()  # no client
+
+        stream_cls.return_value.check_access.assert_not_called()
+        self.assertIn("some_stream", schemas)
+
+
+class TestDiscoverWithAccessCheck(unittest.TestCase):
+    """Unit tests for discover() when a client is provided."""
+
+    def test_discover_with_client_excludes_forbidden_streams(self):
+        """discover(client) must exclude streams returned from get_schemas for which
+        access was denied."""
+        mock_client = MagicMock()
+        allowed_schemas = {"profiles": {"properties": {"profileId": {"type": "string"}}}}
+        allowed_metadata = {"profiles": [{"breadcrumb": [], "metadata": {"table-key-properties": ["profileId"]}}]}
+
+        with patch(
+            "tap_amazon_ads.discover.get_schemas",
+            return_value=(allowed_schemas, allowed_metadata),
+        ) as mock_get_schemas:
+            catalog = discover(mock_client)
+
+        mock_get_schemas.assert_called_once_with(mock_client)
+        catalog_stream_names = {e.stream for e in catalog.streams}
+        self.assertEqual(catalog_stream_names, {"profiles"})
+
+    def test_discover_without_client_calls_get_schemas_with_none(self):
+        """discover() called without a client passes None to get_schemas."""
+        with patch(
+            "tap_amazon_ads.discover.get_schemas",
+            return_value=({}, {}),
+        ) as mock_get_schemas:
+            discover()
+
+        mock_get_schemas.assert_called_once_with(None)

--- a/tests/unittests/test_discovery.py
+++ b/tests/unittests/test_discovery.py
@@ -12,13 +12,13 @@ class TestGetSchemas(unittest.TestCase):
 
     def test_returns_all_streams(self):
         """get_schemas() should return an entry for every stream in STREAMS."""
-        schemas, field_metadata = get_schemas()
+        schemas, field_metadata = get_schemas(None)
         self.assertEqual(set(schemas.keys()), set(STREAMS.keys()))
         self.assertEqual(set(field_metadata.keys()), set(STREAMS.keys()))
 
     def test_schema_properties_are_dicts(self):
         """Every schema returned should have a 'properties' dict."""
-        schemas, _ = get_schemas()
+        schemas, _ = get_schemas(None)
         for stream_name, schema in schemas.items():
             with self.subTest(stream=stream_name):
                 self.assertIn("properties", schema, f"{stream_name} schema missing 'properties'")
@@ -26,7 +26,7 @@ class TestGetSchemas(unittest.TestCase):
 
     def test_incremental_streams_have_replication_key_in_metadata(self):
         """All incremental streams should mark their replication key as 'automatic' in metadata."""
-        _, field_metadata = get_schemas()
+        _, field_metadata = get_schemas(None)
         for stream_name, stream_cls in STREAMS.items():
             rk = getattr(stream_cls, "replication_keys", [])
             if not rk:
@@ -48,7 +48,7 @@ class TestGetSchemas(unittest.TestCase):
 
     def test_primary_keys_in_metadata(self):
         """Every stream should have its key_properties recorded in root metadata."""
-        _, field_metadata = get_schemas()
+        _, field_metadata = get_schemas(None)
         for stream_name, stream_cls in STREAMS.items():
             expected_keys = list(getattr(stream_cls, "key_properties", []))
             mdata_list = field_metadata[stream_name]
@@ -66,7 +66,7 @@ class TestGetSchemas(unittest.TestCase):
 
     def test_replication_method_in_metadata(self):
         """Every stream should have its replication method recorded in root metadata."""
-        _, field_metadata = get_schemas()
+        _, field_metadata = get_schemas(None)
         for stream_name, stream_cls in STREAMS.items():
             expected_method = getattr(stream_cls, "replication_method")
             mdata_list = field_metadata[stream_name]
@@ -80,7 +80,7 @@ class TestGetSchemas(unittest.TestCase):
 
     def test_replication_key_present_in_schema_properties(self):
         """For every incremental stream, the replication key must exist as a schema property."""
-        schemas, _ = get_schemas()
+        schemas, _ = get_schemas(None)
         for stream_name, stream_cls in STREAMS.items():
             rk = getattr(stream_cls, "replication_keys", [])
             if not rk:
@@ -94,7 +94,7 @@ class TestGetSchemas(unittest.TestCase):
 
     def test_replication_key_has_date_time_format(self):
         """Every replication key field in the schema must have format=date-time."""
-        schemas, _ = get_schemas()
+        schemas, _ = get_schemas(None)
         for stream_name, stream_cls in STREAMS.items():
             rk = getattr(stream_cls, "replication_keys", [])
             if not rk:
@@ -109,7 +109,7 @@ class TestGetSchemas(unittest.TestCase):
 
     def test_primary_key_fields_exist_in_schema_properties(self):
         """Every key_property must be a property in the schema."""
-        schemas, _ = get_schemas()
+        schemas, _ = get_schemas(None)
         for stream_name, stream_cls in STREAMS.items():
             keys = getattr(stream_cls, "key_properties", [])
             props = schemas[stream_name].get("properties", {})
@@ -127,18 +127,18 @@ class TestDiscover(unittest.TestCase):
 
     def test_discover_returns_catalog(self):
         """discover() should return a singer Catalog object."""
-        catalog = discover()
+        catalog = discover(None)
         self.assertIsInstance(catalog, Catalog)
 
     def test_discover_catalog_contains_all_streams(self):
         """The catalog should contain an entry for every stream in STREAMS."""
-        catalog = discover()
+        catalog = discover(None)
         catalog_stream_names = {entry.stream for entry in catalog.streams}
         self.assertEqual(catalog_stream_names, set(STREAMS.keys()))
 
     def test_catalog_entry_has_key_properties(self):
         """Every catalog entry must have non-empty key_properties."""
-        catalog = discover()
+        catalog = discover(None)
         for entry in catalog.streams:
             with self.subTest(stream=entry.stream):
                 self.assertIsNotNone(entry.key_properties)
@@ -150,7 +150,7 @@ class TestDiscover(unittest.TestCase):
 
     def test_catalog_entry_has_schema(self):
         """Every catalog entry must have a schema with properties."""
-        catalog = discover()
+        catalog = discover(None)
         for entry in catalog.streams:
             with self.subTest(stream=entry.stream):
                 schema_dict = entry.schema.to_dict()
@@ -158,7 +158,7 @@ class TestDiscover(unittest.TestCase):
 
     def test_catalog_entry_has_metadata(self):
         """Every catalog entry must have metadata."""
-        catalog = discover()
+        catalog = discover(None)
         for entry in catalog.streams:
             with self.subTest(stream=entry.stream):
                 self.assertIsNotNone(entry.metadata)
@@ -166,7 +166,7 @@ class TestDiscover(unittest.TestCase):
 
     def test_catalog_tap_stream_id_matches_stream(self):
         """tap_stream_id must match the stream name for every entry."""
-        catalog = discover()
+        catalog = discover(None)
         for entry in catalog.streams:
             with self.subTest(stream=entry.stream):
                 self.assertEqual(entry.stream, entry.tap_stream_id)
@@ -177,11 +177,11 @@ class TestDiscover(unittest.TestCase):
         bad_metadata = {"broken_stream": []}
         with patch("tap_amazon_ads.discover.get_schemas", return_value=(bad_schemas, bad_metadata)):
             with self.assertRaises(Exception):
-                discover()
+                discover(None)
 
     def test_key_properties_match_stream_class(self):
         """key_properties in catalog must match the stream class definition."""
-        catalog = discover()
+        catalog = discover(None)
         for entry in catalog.streams:
             stream_cls = STREAMS[entry.stream]
             expected = sorted(getattr(stream_cls, "key_properties", []))
@@ -383,7 +383,7 @@ class TestGetSchemasAccessCheck(unittest.TestCase):
         stream_cls = _make_stream_cls(parent="")
 
         with patch("tap_amazon_ads.schema.STREAMS", {"some_stream": stream_cls}):
-            schemas, _ = get_schemas()  # no client
+            schemas, _ = get_schemas(None)  # explicit None — no access check
 
         stream_cls.return_value.check_access.assert_not_called()
         self.assertIn("some_stream", schemas)
@@ -410,11 +410,11 @@ class TestDiscoverWithAccessCheck(unittest.TestCase):
         self.assertEqual(catalog_stream_names, {"profiles"})
 
     def test_discover_without_client_calls_get_schemas_with_none(self):
-        """discover() called without a client passes None to get_schemas."""
+        """discover(None) passes None to get_schemas, skipping access checks."""
         with patch(
             "tap_amazon_ads.discover.get_schemas",
             return_value=({}, {}),
         ) as mock_get_schemas:
-            discover()
+            discover(None)
 
         mock_get_schemas.assert_called_once_with(None)

--- a/tests/unittests/test_sync.py
+++ b/tests/unittests/test_sync.py
@@ -321,9 +321,8 @@ class TestSyncOrchestration(unittest.TestCase):
         mock_stream_instance.parent = ""
         mock_stream_instance.sync.return_value = (5, {})
         mock_stream_cls = MagicMock(return_value=mock_stream_instance)
-        mock_streams.__contains__ = lambda self, item: True
-        mock_streams.__getitem__ = lambda self, key: mock_stream_cls
-        mock_streams.__iter__ = MagicMock(return_value=iter(["test_stream"]))
+        mock_streams.__contains__.side_effect = lambda item: True
+        mock_streams.__getitem__.side_effect = lambda key: mock_stream_cls
 
         catalog = _mock_catalog(["test_stream"])
         client = MagicMock()
@@ -353,9 +352,8 @@ class TestSyncOrchestration(unittest.TestCase):
         def _stream_factory(key):
             return MagicMock(return_value=(parent_instance if key == "parent_stream" else child_instance))
 
-        mock_streams.__contains__ = lambda self, item: item in ("parent_stream", "child_stream")
-        mock_streams.__getitem__ = lambda self, key: _stream_factory(key)
-        mock_streams.__iter__ = MagicMock(return_value=iter(["parent_stream", "child_stream"]))
+        mock_streams.__contains__.side_effect = lambda item: item in ("parent_stream", "child_stream")
+        mock_streams.__getitem__.side_effect = lambda key: _stream_factory(key)
 
         catalog = _mock_catalog(["parent_stream", "child_stream"])
         client = MagicMock()
@@ -379,8 +377,8 @@ class TestSyncOrchestration(unittest.TestCase):
         mock_stream_instance = MagicMock()
         mock_stream_instance.parent = ""
         mock_stream_instance.sync.return_value = (0, {})
-        mock_streams.__contains__ = lambda self, item: True
-        mock_streams.__getitem__ = MagicMock(return_value=MagicMock(return_value=mock_stream_instance))
+        mock_streams.__contains__.side_effect = lambda item: True
+        mock_streams.__getitem__.side_effect = lambda key: MagicMock(return_value=mock_stream_instance)
 
         catalog = _mock_catalog(["my_stream"])
         client = MagicMock()

--- a/tests/unittests/test_sync.py
+++ b/tests/unittests/test_sync.py
@@ -1,0 +1,464 @@
+import unittest
+from unittest.mock import patch, MagicMock, call
+import singer
+from tap_amazon_ads.streams.abstracts import IncrementalStream, FullTableStream
+from tap_amazon_ads.sync import sync, update_currently_syncing, write_schema
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+def _mock_catalog_entry(stream_name, selected=True):
+    entry = MagicMock()
+    entry.stream = stream_name
+    entry.tap_stream_id = stream_name
+    entry.schema = MagicMock()
+    entry.schema.to_dict.return_value = {
+        "properties": {
+            "id": {"type": ["null", "string"]},
+            "lastUpdateDateTime": {"type": ["null", "string"], "format": "date-time"},
+        }
+    }
+    entry.metadata = [
+        {"breadcrumb": [], "metadata": {"selected": selected, "table-key-properties": ["id"]}}
+    ]
+    return entry
+
+
+def _mock_catalog(stream_names):
+    catalog = MagicMock()
+    entries = {name: _mock_catalog_entry(name) for name in stream_names}
+    catalog.get_selected_streams.return_value = [entries[n] for n in stream_names]
+    catalog.get_stream.side_effect = lambda name: entries.get(name, _mock_catalog_entry(name))
+    return catalog
+
+
+def _make_incremental_stream_cls():
+    """Return a lightweight IncrementalStream subclass for use in sync tests."""
+
+    class ConcreteIncremental(IncrementalStream):
+        tap_stream_id = "test_incremental"
+        key_properties = ["id"]
+        replication_keys = ["lastUpdateDateTime"]
+        replication_method = "INCREMENTAL"
+        http_method = "POST"
+        data_key = "items"
+        path = "items/list"
+        pagination_in = "body"
+        parent = ""
+        children = []
+
+    return ConcreteIncremental
+
+
+def _make_full_table_stream_cls():
+    class ConcreteFull(FullTableStream):
+        tap_stream_id = "test_full"
+        key_properties = ["id"]
+        replication_keys = []
+        replication_method = "FULL_TABLE"
+        http_method = "GET"
+        data_key = "items"
+        path = "items"
+        pagination_in = None
+        parent = ""
+        children = []
+
+    return ConcreteFull
+
+
+# ---------------------------------------------------------------------------
+# update_currently_syncing tests
+# ---------------------------------------------------------------------------
+
+class TestUpdateCurrentlySyncing(unittest.TestCase):
+
+    @patch("tap_amazon_ads.sync.singer.write_state")
+    def test_sets_currently_syncing(self, mock_write):
+        state = {}
+        update_currently_syncing(state, "my_stream")
+        self.assertEqual(state.get("currently_syncing"), "my_stream")
+        mock_write.assert_called_once_with(state)
+
+    @patch("tap_amazon_ads.sync.singer.write_state")
+    def test_clears_currently_syncing_when_none(self, mock_write):
+        state = {"currently_syncing": "my_stream"}
+        update_currently_syncing(state, None)
+        self.assertNotIn("currently_syncing", state)
+        mock_write.assert_called_once_with(state)
+
+    @patch("tap_amazon_ads.sync.singer.write_state")
+    def test_write_state_called_on_set(self, mock_write):
+        state = {}
+        update_currently_syncing(state, "stream_a")
+        mock_write.assert_called_once()
+
+    @patch("tap_amazon_ads.sync.singer.write_state")
+    def test_write_state_called_on_clear(self, mock_write):
+        state = {"currently_syncing": "stream_a"}
+        update_currently_syncing(state, None)
+        mock_write.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# IncrementalStream.sync tests
+# ---------------------------------------------------------------------------
+
+class TestIncrementalStreamSync(unittest.TestCase):
+    """Tests for IncrementalStream.sync() behaviour."""
+
+    def _make_stream(self, records, config=None):
+        with patch("tap_amazon_ads.streams.abstracts.metadata.to_map") as mock_to_map:
+            mock_to_map.return_value = {(): {"selected": True}}
+            client = MagicMock()
+            client.config = config or {"start_date": "2024-01-01T00:00:00Z"}
+            client.base_url = "https://advertising.amazon.com"
+            catalog_entry = _mock_catalog_entry("test_incremental")
+            StreamCls = _make_incremental_stream_cls()
+            stream = StreamCls(client=client, catalog=catalog_entry)
+            stream.child_to_sync = []
+            stream.url_endpoint = "https://advertising.amazon.com/items/list"
+
+        with patch.object(stream, "get_records", return_value=iter(records)):
+            return stream
+
+    @patch("tap_amazon_ads.streams.abstracts.write_record")
+    @patch("tap_amazon_ads.streams.abstracts.metrics.record_counter")
+    def test_syncs_records_newer_than_bookmark(self, mock_counter, mock_write_record):
+        """Only records >= bookmark should be written."""
+        mock_ctx = MagicMock()
+        mock_ctx.__enter__ = MagicMock(return_value=mock_ctx)
+        mock_ctx.__exit__ = MagicMock(return_value=False)
+        mock_counter.return_value = mock_ctx
+
+        records = [
+            {"id": "1", "lastUpdateDateTime": "2024-06-01T00:00:00Z"},  # after bookmark
+            {"id": "2", "lastUpdateDateTime": "2023-12-01T00:00:00Z"},  # before bookmark
+        ]
+        state = {"bookmarks": {"test_incremental": {"lastUpdateDateTime": "2024-01-01T00:00:00Z"}}}
+        stream = self._make_stream(records)
+
+        with patch.object(stream, "get_records", return_value=iter(records)), \
+             singer.Transformer() as transformer:
+            stream.sync(state=state, transformer=transformer)
+
+        # Only record 1 is newer than the bookmark
+        self.assertEqual(mock_write_record.call_count, 1)
+        written_record = mock_write_record.call_args[0][1]
+        self.assertEqual(written_record["id"], "1")
+
+    @patch("tap_amazon_ads.streams.abstracts.write_record")
+    @patch("tap_amazon_ads.streams.abstracts.metrics.record_counter")
+    def test_bookmark_advances_after_sync(self, mock_counter, mock_write_record):
+        """After sync the bookmark should advance to the max record date."""
+        mock_ctx = MagicMock()
+        mock_ctx.__enter__ = MagicMock(return_value=mock_ctx)
+        mock_ctx.__exit__ = MagicMock(return_value=False)
+        mock_counter.return_value = mock_ctx
+
+        records = [
+            {"id": "1", "lastUpdateDateTime": "2025-03-01T00:00:00Z"},
+            {"id": "2", "lastUpdateDateTime": "2025-06-15T00:00:00Z"},
+        ]
+        state = {"bookmarks": {"test_incremental": {"lastUpdateDateTime": "2025-01-01T00:00:00Z"}}}
+        stream = self._make_stream(records)
+
+        with patch.object(stream, "get_records", return_value=iter(records)), \
+             singer.Transformer() as transformer:
+            _, final_state = stream.sync(state=state, transformer=transformer)
+
+        bk = final_state["bookmarks"]["test_incremental"]["lastUpdateDateTime"]
+        self.assertEqual(bk, "2025-06-15T00:00:00Z")
+
+    @patch("tap_amazon_ads.streams.abstracts.write_record")
+    @patch("tap_amazon_ads.streams.abstracts.metrics.record_counter")
+    def test_zero_records_returns_zero_count(self, mock_counter, mock_write_record):
+        """A sync with no records should return 0 and not write any records."""
+        mock_ctx = MagicMock()
+        mock_ctx.__enter__ = MagicMock(return_value=mock_ctx)
+        mock_ctx.__exit__ = MagicMock(return_value=False)
+        mock_ctx.value = 0
+        mock_counter.return_value = mock_ctx
+
+        state = {}
+        stream = self._make_stream([])
+
+        with patch.object(stream, "get_records", return_value=iter([])), \
+             singer.Transformer() as transformer:
+            count, _ = stream.sync(state=state, transformer=transformer)
+
+        mock_write_record.assert_not_called()
+        self.assertEqual(count, 0)
+
+    @patch("tap_amazon_ads.streams.abstracts.write_record")
+    @patch("tap_amazon_ads.streams.abstracts.metrics.record_counter")
+    def test_child_sync_called_for_each_parent_record(self, mock_counter, mock_write_record):
+        """child.sync() must be called once per qualifying parent record."""
+        mock_ctx = MagicMock()
+        mock_ctx.__enter__ = MagicMock(return_value=mock_ctx)
+        mock_ctx.__exit__ = MagicMock(return_value=False)
+        mock_counter.return_value = mock_ctx
+
+        records = [
+            {"id": "1", "lastUpdateDateTime": "2025-01-01T00:00:00Z"},
+            {"id": "2", "lastUpdateDateTime": "2025-02-01T00:00:00Z"},
+        ]
+        state = {"bookmarks": {"test_incremental": {"lastUpdateDateTime": "2024-01-01T00:00:00Z"}}}
+        stream = self._make_stream(records)
+
+        mock_child = MagicMock()
+        stream.child_to_sync = [mock_child]
+
+        with patch.object(stream, "get_records", return_value=iter(records)), \
+             singer.Transformer() as transformer:
+            stream.sync(state=state, transformer=transformer)
+
+        self.assertEqual(mock_child.sync.call_count, 2)
+
+    @patch("tap_amazon_ads.streams.abstracts.write_record")
+    @patch("tap_amazon_ads.streams.abstracts.metrics.record_counter")
+    def test_modify_object_called_for_each_record(self, mock_counter, mock_write_record):
+        """modify_object should be invoked for every record during sync."""
+        mock_ctx = MagicMock()
+        mock_ctx.__enter__ = MagicMock(return_value=mock_ctx)
+        mock_ctx.__exit__ = MagicMock(return_value=False)
+        mock_counter.return_value = mock_ctx
+
+        records = [
+            {"id": "1", "lastUpdateDateTime": "2025-01-01T00:00:00Z"},
+            {"id": "2", "lastUpdateDateTime": "2025-02-01T00:00:00Z"},
+        ]
+        state = {}
+        stream = self._make_stream(records)
+
+        with patch.object(stream, "get_records", return_value=iter(records)), \
+             patch.object(stream, "modify_object", wraps=stream.modify_object) as mock_modify, \
+             singer.Transformer() as transformer:
+            stream.sync(state=state, transformer=transformer)
+
+        self.assertEqual(mock_modify.call_count, 2)
+
+
+# ---------------------------------------------------------------------------
+# FullTableStream.sync tests
+# ---------------------------------------------------------------------------
+
+class TestFullTableStreamSync(unittest.TestCase):
+    """Tests for FullTableStream.sync() behaviour."""
+
+    def _make_stream(self, records):
+        with patch("tap_amazon_ads.streams.abstracts.metadata.to_map") as mock_to_map:
+            mock_to_map.return_value = {(): {"selected": True}}
+            client = MagicMock()
+            client.config = {"start_date": "2024-01-01T00:00:00Z"}
+            client.base_url = "https://advertising.amazon.com"
+            catalog_entry = _mock_catalog_entry("test_full")
+            StreamCls = _make_full_table_stream_cls()
+            stream = StreamCls(client=client, catalog=catalog_entry)
+            stream.child_to_sync = []
+            stream.url_endpoint = "https://advertising.amazon.com/items"
+        return stream
+
+    @patch("tap_amazon_ads.streams.abstracts.write_record")
+    @patch("tap_amazon_ads.streams.abstracts.metrics.record_counter")
+    def test_all_records_written(self, mock_counter, mock_write_record):
+        """Full table sync writes every record regardless of timestamp."""
+        mock_ctx = MagicMock()
+        mock_ctx.__enter__ = MagicMock(return_value=mock_ctx)
+        mock_ctx.__exit__ = MagicMock(return_value=False)
+        mock_counter.return_value = mock_ctx
+
+        records = [{"id": "1"}, {"id": "2"}, {"id": "3"}]
+        stream = self._make_stream(records)
+
+        with patch.object(stream, "get_records", return_value=iter(records)), \
+             singer.Transformer() as transformer:
+            stream.sync(state={}, transformer=transformer)
+
+        self.assertEqual(mock_write_record.call_count, 3)
+
+    @patch("tap_amazon_ads.streams.abstracts.write_record")
+    @patch("tap_amazon_ads.streams.abstracts.metrics.record_counter")
+    def test_does_not_update_state(self, mock_counter, mock_write_record):
+        """Full table sync returns unmodified state (no bookmarking)."""
+        mock_ctx = MagicMock()
+        mock_ctx.__enter__ = MagicMock(return_value=mock_ctx)
+        mock_ctx.__exit__ = MagicMock(return_value=False)
+        mock_counter.return_value = mock_ctx
+
+        initial_state = {"bookmarks": {"other_stream": {"field": "value"}}}
+        records = [{"id": "1"}]
+        stream = self._make_stream(records)
+
+        with patch.object(stream, "get_records", return_value=iter(records)), \
+             singer.Transformer() as transformer:
+            _, final_state = stream.sync(state=initial_state, transformer=transformer)
+
+        # Full table streams must not add any new bookmark keys
+        self.assertEqual(final_state.get("bookmarks", {}), {"other_stream": {"field": "value"}})
+
+
+# ---------------------------------------------------------------------------
+# sync() orchestration tests
+# ---------------------------------------------------------------------------
+
+class TestSyncOrchestration(unittest.TestCase):
+    """Tests for the top-level sync() function in tap_amazon_ads.sync."""
+
+    def _base_config(self):
+        return {"start_date": "2024-01-01T00:00:00Z"}
+
+    @patch("tap_amazon_ads.sync.singer.write_state")
+    @patch("tap_amazon_ads.sync.update_currently_syncing")
+    @patch("tap_amazon_ads.sync.write_schema")
+    @patch("tap_amazon_ads.sync.STREAMS")
+    def test_sync_iterates_selected_streams(
+        self, mock_streams, mock_write_schema, mock_update_sync, mock_write_state
+    ):
+        """sync() should call stream.sync() for every selected, non-child stream."""
+        mock_stream_instance = MagicMock()
+        mock_stream_instance.parent = ""
+        mock_stream_instance.sync.return_value = (5, {})
+        mock_stream_cls = MagicMock(return_value=mock_stream_instance)
+        mock_streams.__contains__ = lambda self, item: True
+        mock_streams.__getitem__ = lambda self, key: mock_stream_cls
+        mock_streams.__iter__ = MagicMock(return_value=iter(["test_stream"]))
+
+        catalog = _mock_catalog(["test_stream"])
+        client = MagicMock()
+        state = {}
+
+        with patch("tap_amazon_ads.sync.singer.Transformer"):
+            sync(client, self._base_config(), catalog, state)
+
+        mock_stream_instance.sync.assert_called_once()
+
+    @patch("tap_amazon_ads.sync.singer.write_state")
+    @patch("tap_amazon_ads.sync.update_currently_syncing")
+    @patch("tap_amazon_ads.sync.write_schema")
+    @patch("tap_amazon_ads.sync.STREAMS")
+    def test_sync_skips_child_streams_at_top_level(
+        self, mock_streams, mock_write_schema, mock_update_sync, mock_write_state
+    ):
+        """Child streams (parent != '') must not be synced directly at the top level."""
+        # parent_stream has no parent; child_stream is a child of parent_stream
+        parent_instance = MagicMock()
+        parent_instance.parent = ""
+        parent_instance.sync.return_value = (3, {})
+
+        child_instance = MagicMock()
+        child_instance.parent = "parent_stream"
+
+        def _stream_factory(key):
+            return MagicMock(return_value=(parent_instance if key == "parent_stream" else child_instance))
+
+        mock_streams.__contains__ = lambda self, item: item in ("parent_stream", "child_stream")
+        mock_streams.__getitem__ = lambda self, key: _stream_factory(key)
+        mock_streams.__iter__ = MagicMock(return_value=iter(["parent_stream", "child_stream"]))
+
+        catalog = _mock_catalog(["parent_stream", "child_stream"])
+        client = MagicMock()
+        state = {}
+
+        with patch("tap_amazon_ads.sync.singer.Transformer"):
+            sync(client, self._base_config(), catalog, state)
+
+        # Only parent is synced directly
+        parent_instance.sync.assert_called_once()
+        child_instance.sync.assert_not_called()
+
+    @patch("tap_amazon_ads.sync.singer.write_state")
+    @patch("tap_amazon_ads.sync.update_currently_syncing")
+    @patch("tap_amazon_ads.sync.write_schema")
+    @patch("tap_amazon_ads.sync.STREAMS")
+    def test_currently_syncing_set_and_cleared(
+        self, mock_streams, mock_write_schema, mock_update_sync, mock_write_state
+    ):
+        """update_currently_syncing must be called once before and once after each stream."""
+        mock_stream_instance = MagicMock()
+        mock_stream_instance.parent = ""
+        mock_stream_instance.sync.return_value = (0, {})
+        mock_streams.__contains__ = lambda self, item: True
+        mock_streams.__getitem__ = MagicMock(return_value=MagicMock(return_value=mock_stream_instance))
+
+        catalog = _mock_catalog(["my_stream"])
+        client = MagicMock()
+        state = {}
+
+        with patch("tap_amazon_ads.sync.singer.Transformer"):
+            sync(client, self._base_config(), catalog, state)
+
+        # Called once to set ("my_stream") and once to clear (None)
+        calls = mock_update_sync.call_args_list
+        stream_names = [c[0][1] for c in calls]
+        self.assertIn("my_stream", stream_names)
+        self.assertIn(None, stream_names)
+
+
+# ---------------------------------------------------------------------------
+# get_records / pagination tests
+# ---------------------------------------------------------------------------
+
+class TestGetRecords(unittest.TestCase):
+    """Tests for BaseStream.get_records() pagination behaviour."""
+
+    def _make_stream(self):
+        with patch("tap_amazon_ads.streams.abstracts.metadata.to_map") as mock_to_map:
+            mock_to_map.return_value = {(): {"selected": True}}
+            client = MagicMock()
+            client.config = {"start_date": "2024-01-01T00:00:00Z"}
+            client.base_url = "https://advertising.amazon.com"
+            catalog_entry = _mock_catalog_entry("test_incremental")
+            StreamCls = _make_incremental_stream_cls()
+            stream = StreamCls(client=client, catalog=catalog_entry)
+            stream.child_to_sync = []
+            stream.url_endpoint = "https://advertising.amazon.com/items"
+        return stream
+
+    def test_single_page_list_response(self):
+        """A list response is returned directly and pagination stops."""
+        stream = self._make_stream()
+        stream.client.make_request.return_value = [{"id": "1"}, {"id": "2"}]
+        records = list(stream.get_records())
+        self.assertEqual(len(records), 2)
+        self.assertEqual(stream.client.make_request.call_count, 1)
+
+    def test_dict_response_extracts_data_key(self):
+        """A dict response extracts items under data_key and stops when no nextToken."""
+        stream = self._make_stream()
+        stream.client.make_request.return_value = {"items": [{"id": "A"}, {"id": "B"}]}
+        records = list(stream.get_records())
+        self.assertEqual(len(records), 2)
+
+    def test_paginated_dict_response(self):
+        """Pagination continues while nextToken is present; stops when absent."""
+        stream = self._make_stream()
+        stream.pagination_in = "body"
+        stream.next_page_key = "nextToken"
+
+        page1 = {"items": [{"id": "1"}, {"id": "2"}], "nextToken": "tok123"}
+        page2 = {"items": [{"id": "3"}]}
+
+        stream.client.make_request.side_effect = [page1, page2]
+        records = list(stream.get_records())
+
+        self.assertEqual(len(records), 3)
+        self.assertEqual(stream.client.make_request.call_count, 2)
+        # The second page request must have included the token in the payload
+        second_call_kwargs = stream.client.make_request.call_args_list[1]
+        self.assertIn("tok123", str(second_call_kwargs))
+
+    def test_unexpected_response_type_raises(self):
+        """A response that is neither list nor dict raises TypeError."""
+        stream = self._make_stream()
+        stream.client.make_request.return_value = "unexpected string"
+        with self.assertRaises(TypeError):
+            list(stream.get_records())
+
+    def test_empty_data_key_returns_no_records(self):
+        """If the data key is missing from the response, no records are yielded."""
+        stream = self._make_stream()
+        stream.client.make_request.return_value = {"other_key": [{"id": "1"}]}
+        records = list(stream.get_records())
+        self.assertEqual(records, [])


### PR DESCRIPTION
# Description of change
PR include execution for streams that the configured credentials cannot access (HTTP 403) are now silently excluded from the catalog during discovery. Their child streams are excluded as well. Previously, a 403 on any stream caused discovery to fail entirely. Unit tests added covering: discovery schema/metadata, access-check filtering, bookmark read/write, `modify_object` replication-key promotion, incremental and full-table stream sync, sync orchestration, and `get_records` pagination.

# Manual QA steps
- [x]  Discovery: Running
- [x]  Sync: Running
- [x]  Unit Tests: Running
- [x]  Integration test: Running
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
